### PR TITLE
Update EmoteMenu.lua

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -661,7 +661,6 @@ function OpenEmoteMenu()
     end
 end
 
-LoadAddonEmotes()
 AddEmoteMenu(mainMenu)
 AddCancelEmote(mainMenu)
 ShowPedPreview(mainMenu)


### PR DESCRIPTION
Removes line 664 "LoadAddonEmotes()"
Not sure what this does, but having it in breaks the script, and taking it out fixes it...so if it works it works I guess?

ref: [rpemotes-reborn FiveM forums thread](https://forum.cfx.re/t/free-rpemotes-reborn-a-standalone-emote-system-for-fivem/5219460/42?u=blackfirefly000)

This solution is a quick and dirty "if it works, it works" solution and exists only to get the resource working again. This does not take into account the purpose of the above line of code, has not been tested extensively, and may result in feature loss or other issues. 