### PR TITLE
[fix] state canEmote [Utils.lua]

### DIFF
--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -1,3 +1,5 @@
+LocalPlayer.state:set('canEmote', true, true) -- Allow emotes to be played by default
+
 -- You can edit this function to add support for your favorite notification system
 function SimpleNotify(message)
     if Config.NotificationsAsChatMessage then


### PR DESCRIPTION
Set canEmote to true by default on first load, if needed it should be disabled by other scripts later on.
Idk the best place for this to be set, maybe playerSpawned handler, but should work like this too, because current handlers is under Config true/false which we don't want for this specific toggle, so I guess give a shot like this.

Additional fix for #23 