### PR TITLE
fix: deleting saved kvp expression when resetting from the menu

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -536,6 +536,7 @@ function AddFaceMenu(menu)
         if item ~= facereset then
             EmoteMenuStart(FaceTable[index], "expression")
         else
+            DeleteResourceKvp("expression")
             ClearFacialIdleAnimOverride(PlayerPedId())
         end
     end


### PR DESCRIPTION
This was previously only being done via the command