### PR TITLE
chore: add typing to animation list

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -2,6 +2,8 @@
 -- If an emote does not work, you may be on an older gamebuild --
 -- To get a higher gamebuild, see ReadMe on github repository --
 
+---@type AnimationListConfig | table<string, EmoteData>
+---@diagnostic disable-next-line: missing-fields
 RP = {}
 
 -- EXPRESSIONS --

--- a/client/AnimationListCustom.lua
+++ b/client/AnimationListCustom.lua
@@ -5,6 +5,8 @@
 -- Remove the } from the = {} then enter your own animation code ---
 -- Don't forget to close the tables.
 
+---@type AnimationListConfig?
+---@diagnostic disable-next-line: missing-fields
 local CustomDP = {}
 
 CustomDP.Expressions = {}
@@ -27,6 +29,7 @@ function LoadAddonEmotes()
         PropEmotes = '📦 '
     }
 
+    assert(CustomDP ~= nil, 'Addon emotes can only be loaded once')
     for arrayName, array in pairs(CustomDP) do
         if RP[arrayName] then
             local prefix = prefixes[arrayName]

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -6,7 +6,7 @@ InHandsup = false
 CONVERTED = false
 
 local ChosenDict = ""
-local CurrentAnimOptions = false
+local CurrentAnimOptions
 local PlayerGender = "male"
 local PlayerProps = {}
 local PreviewPedProps = {}
@@ -511,6 +511,7 @@ function OnEmotePlay(name, textureVariation)
     end
 
     if ChosenDict == "MaleScenario" or ChosenDict == "Scenario" or ChosenDict == "ScenarioObject" then
+        assert(anim ~= nil)
         if InVehicle then return end
         CheckGender()
         ClearPedTasks(PlayerPedId())
@@ -584,6 +585,7 @@ function OnEmotePlay(name, textureVariation)
         ClearPedTasksImmediately(PlayerPedId())
     end
 
+    assert(anim ~= nil)
     TaskPlayAnim(PlayerPedId(), ChosenDict, anim, animOption?.BlendInSpeed or 5.0, animOption?.BlendOutSpeed or 5.0, animOption?.EmoteDuration or -1, animOption?.Flag or movementType, 0, false, false,
         false)
     RemoveAnimDict(ChosenDict)

--- a/types.lua
+++ b/types.lua
@@ -1,0 +1,76 @@
+---@meta
+
+---@alias Dictionary string
+---@alias AnimName string
+---@alias ScenarioName string
+---@alias Label string
+
+---@class Color
+---@field R number
+---@field G number
+---@field B number
+---@field A number
+
+---@class AnimationOptions
+---@field EmoteMoving? boolean
+---@field EmoteLoop? boolean
+---@field EmoteStuck? boolean
+---@field FullBody? boolean
+---@field Attachto? boolean
+---@field NotInVehicle? boolean
+---@field onlyInVehicle? boolean
+---@field EmoteDuration? integer
+---@field SyncOffsetFront? number
+---@field SyncOffsetSide? number
+---@field SyncOffsetHeading? number
+---@field bone? integer
+---@field xPos? number
+---@field yPos? number
+---@field zPos? number
+---@field xRot? number
+---@field yRot? number
+---@field zRot? number
+---@field Prop? string
+---@field PropBone? integer
+---@field PropPlacement? number[]
+---@field PropNoCollision? boolean
+---@field StartDelay? integer
+---@field SecondProp? string
+---@field SecondPropBone? integer
+---@field SecondPropPlacement? number[]
+---@field SecondPropNoCollision? boolean
+---@field PropTextureVariations? {Name: string, Value: integer}[]
+---@field PtfxAsset? string
+---@field PtfxName? string
+---@field PtfxNoProp? boolean
+---@field PtfxPlacement? number[]
+---@field PtfxInfo? string
+---@field PtfxWait? number
+---@field PtfxCanHold? boolean
+---@field PtfxColor? Color[]
+---@field PtfxBone? integer
+---@field ExitEmote? string
+---@field ExitEmoteType? "Exits"
+---@field BlendInSpeed? number
+---@field BlendOutSpeed? number
+---@field Flag? integer
+
+---@class AnimationListConfig
+---@field Expressions table<string, {[1]: AnimName, [2]: Label?}>
+---@field Walks table<string, {[1]: AnimName, [2]: Label?}>
+---@field Shared table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, [4]: AnimName?, AnimationOptions?: AnimationOptions, AnimalEmote?: boolean}>
+---@field Dances table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
+---@field AnimalEmotes table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions, AdultAnimation?: boolean, AnimalEmote?: boolean}>
+---@field Exits table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
+---@field Emotes table<string, {[1]: Dictionary | 'MaleScenario' | 'Scenario', [2]: AnimName | ScenarioName, [3]: Label, AnimationOptions?: AnimationOptions, AdultAnimation?: boolean}>
+---@field PropEmotes table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
+
+---@class EmoteData
+---@field [1] AnimName | Dictionary | 'MaleScenario' | 'Scenario' | 'ScenarioObject'
+---@field [2] AnimName | ScenarioName | Label?
+---@field [3]? Label
+---@field [4]? AnimName Second player's anim during a shared emote. Defaults to the same as first player if unset.
+---@field AnimationOptions? AnimationOptions
+---@field AnimalEmote? boolean
+---@field AdultAnimation? boolean
+---@field category 'Expressions' | 'Walks' | 'Shared' | 'Dances' | 'AnimalEmotes' | 'Exits' | 'Emotes' | 'PropEmotes'


### PR DESCRIPTION
- Adds types.lua as a meta file for containing [Lua language server types](https://luals.github.io) to define the fields and values used in the animation list contained in the "RP" variable, which is then subsequently flattened for internal use within logic. I'm calling the config like animation list "AnimationListConfig", and the internal flattened version "EmoteData."
- Adds some assertions in some places in the logic where the logic expects a field to exist but the typing does not guarantee it does.

While changing the structure of AnimationListConfig could potentially break servers who have modified or added their own animations, EmoteData can and should be modified in future PRs to use stronger types to improve readability. Overloading generic keys like 1, 2, 3, 4 can make the logic difficult to understand and error prone as certain value types are assumed based on the values of other fields.