### PR TITLE
refactor: Use new variable instead of overloading RP for converted form

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -2,7 +2,7 @@
 -- If an emote does not work, you may be on an older gamebuild --
 -- To get a higher gamebuild, see ReadMe on github repository --
 
----@type AnimationListConfig | table<string, EmoteData>
+---@type AnimationListConfig
 ---@diagnostic disable-next-line: missing-fields
 RP = {}
 

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -18,7 +18,7 @@ local function ResetCrouch()
 
     local walkstyle = GetResourceKvpString("walkstyle")
     if walkstyle then
-        local toApply = RP[walkstyle]
+        local toApply = EmoteData[walkstyle]
         if not toApply or type(toApply) ~= "table" or toApply.category ~= "Walks" then
             ResetPedMovementClipset(playerPed, 0.5)
             DeleteResourceKvp("walkstyle")

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -186,7 +186,7 @@ function EmoteCancel(force)
             local options = CurrentAnimOptions
             local ExitEmoteType = options.ExitEmoteType or "Emotes"
 
-            if not RP[options.ExitEmote] then
+            if not EmoteData[options.ExitEmote] then
                 DebugPrint("Exit emote was invalid")
                 IsInAnimation = false
                 ClearPedTasks(ped)
@@ -196,7 +196,7 @@ function EmoteCancel(force)
             OnEmotePlay(options.ExitEmote)
             DebugPrint("Playing exit animation")
 
-            local animationOptions = RP[options.ExitEmote].AnimationOptions
+            local animationOptions = EmoteData[options.ExitEmote].AnimationOptions
             if animationOptions and animationOptions.EmoteDuration then
                 InExitEmote = true
                 SetTimeout(animationOptions.EmoteDuration, function()
@@ -220,7 +220,7 @@ function EmoteCancel(force)
 end
 
 function EmoteMenuStart(name, category, textureVariation)
-    local emote = RP[name]
+    local emote = EmoteData[name]
 
     if not emote then
         return
@@ -248,7 +248,7 @@ function EmoteMenuStartClone(name, category)
     if not Config.PreviewPed then return end
     if not DoesEntityExist(ClonedPed) then return end
 
-    local emote = RP[name]
+    local emote = EmoteData[name]
 
     if not emote then
         return
@@ -295,7 +295,7 @@ function EmoteCommandStart(args)
             return
         end
 
-        local emote = RP[name]
+        local emote = EmoteData[name]
         if emote then
             if emote.category == "AnimalEmotes" then
                 if Config.AnimalEmotesEnabled then
@@ -437,7 +437,7 @@ RegisterNetEvent('animations:ToggleCanDoAnims', function(value)
 end)
 
 function OnEmotePlay(name, textureVariation)
-    local emoteData = RP[name]
+    local emoteData = EmoteData[name]
     if not emoteData then
         EmoteChatMessage("'" .. name .. "' " .. Translate('notvalidemote') .. "")
         return
@@ -484,7 +484,7 @@ function OnEmotePlay(name, textureVariation)
     end
 
     if CurrentAnimOptions and CurrentAnimOptions.ExitEmote and animOption and animOption.ExitEmote then
-        if not (animOption and CurrentAnimOptions.ExitEmote == animOption.ExitEmote) and RP[CurrentAnimOptions.ExitEmote][2] ~= emoteData[2] then
+        if not (animOption and CurrentAnimOptions.ExitEmote == animOption.ExitEmote) and EmoteData[CurrentAnimOptions.ExitEmote][2] ~= emoteData[2] then
             return
         end
     end
@@ -598,7 +598,7 @@ function OnEmotePlay(name, textureVariation)
     end
 
     local currentEmoteTable = emoteData
-    for _, tabledata in pairs(RP) do
+    for _, tabledata in pairs(EmoteData) do
         for command, emotedata in pairs(tabledata) do
             if emotedata == emoteData then
                 currentEmoteTable[#currentEmoteTable+1] = command
@@ -666,7 +666,7 @@ function OnEmotePlayClone(name)
         return
     end
 
-    local emoteData = RP[name]
+    local emoteData = EmoteData[name]
     local animOption = emoteData.AnimationOptions
 
     local dict, anim = table.unpack(emoteData)
@@ -774,7 +774,7 @@ function PlayExitAndEnterEmote(name, textureVariation)
     if CurrentAnimOptions?.ExitEmote then
         local options = CurrentAnimOptions or {}
 
-        if not RP[options.ExitEmote] then
+        if not EmoteData[options.ExitEmote] then
             DebugPrint("Exit emote was invalid")
             ClearPedTasks(ped)
             IsInAnimation = false
@@ -783,7 +783,7 @@ function PlayExitAndEnterEmote(name, textureVariation)
         OnEmotePlay(options.ExitEmote)
         DebugPrint("Playing exit animation")
 
-        local animationOptions = RP[options.ExitEmote].AnimationOptions
+        local animationOptions = EmoteData[options.ExitEmote].AnimationOptions
         if animationOptions and animationOptions.EmoteDuration then
             InExitEmote = true
             SetTimeout(animationOptions.EmoteDuration, function()

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -1,3 +1,6 @@
+---@type table<string, EmoteData>
+EmoteData = {}
+
 local isSearching = false
 local rightPosition = { x = 1430, y = 200 }
 local leftPosition = { x = 0, y = 200 }
@@ -209,7 +212,7 @@ if Config.Search then
         local input = GetOnscreenKeyboardResult()
         if input ~= nil then
             local results = {}
-            for a, b in pairs(RP) do
+            for a, b in pairs(EmoteData) do
                 if not ignoredCategories[b.category] then
                     if string.find(string.lower(a), string.lower(input)) or (b[3] ~= nil and string.find(string.lower(b[3]), string.lower(input))) then
                         results[#results + 1] = { table = b.category, name = a, data = b }
@@ -464,6 +467,7 @@ CreateThread(function()
     _menuPool:RefreshIndex()
 
     local newRP = {}
+    assert(RP ~= nil)
     for emoteType, content in pairs(RP) do
         for emoteName, emoteData in pairs(content) do
             local shouldRemove = false
@@ -488,7 +492,8 @@ CreateThread(function()
         end
         newRP[emoteType] = nil
     end
-    RP = newRP
+    EmoteData = newRP
+    RP = nil
     CONVERTED = true
 end)
 

--- a/client/Expressions.lua
+++ b/client/Expressions.lua
@@ -1,5 +1,5 @@
 function SetPlayerPedExpression(expression, saveToKvp)
-    local emote = RP[expression]
+    local emote = EmoteData[expression]
     if emote and emote.category == "Expressions" then
         SetFacialIdleAnimOverride(PlayerPedId(), emote[1], 0)
         if Config.PersistentExpression and saveToKvp then SetResourceKvp("expression", emote[1]) end
@@ -12,9 +12,9 @@ end
 if Config.ExpressionsEnabled then
     RegisterCommand('mood', function(_source, args, _raw)
         local expression = FirstToUpper(string.lower(args[1]))
-        local emote = RP[expression]
+        local emote = EmoteData[expression]
         if emote and emote.category == "Expressions" then
-            SetPlayerPedExpression(RP[expression][1], true)
+            SetPlayerPedExpression(EmoteData[expression][1], true)
         elseif expression == "Reset" then
             ClearFacialIdleAnimOverride(PlayerPedId())
             DeleteResourceKvp("expression")

--- a/client/Handsup.lua
+++ b/client/Handsup.lua
@@ -62,7 +62,7 @@ if Config.HandsupEnabled then
             LocalPlayer.state:set('currentEmote', nil, true)
             ClearPedSecondaryTask(PlayerPedId())
             if Config.ReplayEmoteAfterHandsup and IsInAnimation then
-                local emote = RP[CurrentAnimationName]
+                local emote = EmoteData[CurrentAnimationName]
                 if not emote then
                     return
                 end

--- a/client/Keybinds.lua
+++ b/client/Keybinds.lua
@@ -59,7 +59,7 @@ if Config.Keybinding then
                 return
             end
             if type(numkey) == "number" then
-                if RP[emote] then
+                if EmoteData[emote] then
                     SetResourceKvp(string.format('%s_emob%s', Config.keybindKVP, numkey), emote)
                 else
                     EmoteChatMessage("'" .. emote .. "' " .. Translate('notvalidemote') .. "")

--- a/client/Pointing.lua
+++ b/client/Pointing.lua
@@ -24,7 +24,7 @@ local function PointingStopped()
     end
     RemoveAnimDict("anim@mp_point")
     if Config.ReplayEmoteAfterPointing and IsInAnimation then
-        local emote = RP[CurrentAnimationName]
+        local emote = EmoteData[CurrentAnimationName]
         if not emote then
             return
         end

--- a/client/Syncing.lua
+++ b/client/Syncing.lua
@@ -12,8 +12,8 @@ if Config.SharedEmotesEnabled then
             local emotename = string.lower(args[1])
             local target, distance = GetClosestPlayer()
             if (distance ~= -1 and distance < 3) then
-                if RP[emotename] ~= nil and RP[emotename].category == "Shared" then
-                    local _, _, ename = table.unpack(RP[emotename])
+                if EmoteData[emotename] ~= nil and EmoteData[emotename].category == "Shared" then
+                    local _, _, ename = table.unpack(EmoteData[emotename])
                     TriggerServerEvent("rpemotes:server:requestEmote", GetPlayerServerId(target), emotename)
                     SimpleNotify(Translate('sentrequestto') ..
                         GetPlayerName(target) .. " ~w~(~g~" .. ename .. "~w~)")
@@ -39,11 +39,11 @@ RegisterNetEvent("rpemotes:client:syncEmote", function(emote, player)
         return EmoteChatMessage(Translate('not_in_a_vehicle'))
     end
 
-    if RP[emote] then
-        local options = RP[emote].AnimationOptions
+    if EmoteData[emote] then
+        local options = EmoteData[emote].AnimationOptions
         if options and options.Attachto then
-            local targetEmote = RP[emote][4]
-            if not targetEmote or not RP[targetEmote] or not RP[targetEmote].AnimationOptions or not RP[targetEmote].AnimationOptions.Attachto then
+            local targetEmote = EmoteData[emote][4]
+            if not targetEmote or not EmoteData[targetEmote] or not EmoteData[targetEmote].AnimationOptions or not EmoteData[targetEmote].AnimationOptions.Attachto then
                 local ped = PlayerPedId()
                 local pedInFront = GetPlayerPed(plyServerId ~= 0 and plyServerId or GetClosestPlayer())
 
@@ -83,7 +83,7 @@ RegisterNetEvent("rpemotes:client:syncEmoteSource", function(emote, player)
         return EmoteChatMessage(Translate('not_in_a_vehicle'))
     end
 
-    local options = RP[emote] and RP[emote].AnimationOptions
+    local options = EmoteData[emote] and EmoteData[emote].AnimationOptions
     if options then
         if (options.Attachto) then
             AttachEntityToEntity(
@@ -114,7 +114,7 @@ RegisterNetEvent("rpemotes:client:syncEmoteSource", function(emote, player)
     Wait(300)
 
     targetPlayerId = player
-    if RP[emote] ~= nil then
+    if EmoteData[emote] ~= nil then
         OnEmotePlay(emote)
         return
     end
@@ -137,7 +137,7 @@ end
 RegisterNetEvent("rpemotes:client:requestEmote", function(emotename, etype, target)
     isRequestAnim = true
 
-    local displayed = RP[emotename] and select(3, table.unpack(RP[emotename]))
+    local displayed = EmoteData[emotename] and select(3, table.unpack(EmoteData[emotename]))
 
     PlaySound(-1, "NAV", "HUD_AMMO_SHOP_SOUNDSET", false, 0, true)
     SimpleNotify(Translate('doyouwanna') .. displayed .. "~w~)")
@@ -154,7 +154,7 @@ RegisterNetEvent("rpemotes:client:requestEmote", function(emotename, etype, targ
         if IsControlJustPressed(1, 246) then
             isRequestAnim = false
 
-            local otheremote = RP[emotename] and RP[emotename][4] or emotename
+            local otheremote = EmoteData[emotename] and EmoteData[emotename][4] or emotename
             TriggerServerEvent("rpemotes:server:confirmEmote", target, emotename, otheremote)
         elseif IsControlJustPressed(1, 182) then
             isRequestAnim = false

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -147,7 +147,7 @@ end
 
 function NearbysOnCommand(source, args, raw)
     local NearbysCommand = ""
-    for a, b in PairsByKeys(RP) do
+    for a, b in PairsByKeys(EmoteData) do
         if type(b) == "table" and b.category == "Shared" then
             NearbysCommand = NearbysCommand .. a .. ", "
         end

--- a/client/Walk.lua
+++ b/client/Walk.lua
@@ -11,12 +11,12 @@ function WalkMenuStart(name, force)
         ResetWalk()
         return
     end
-    if not RP[name] or type(RP[name]) ~= "table" or RP[name].category ~= "Walks" then
+    if not EmoteData[name] or type(EmoteData[name]) ~= "table" or EmoteData[name].category ~= "Walks" then
         EmoteChatMessage("'" .. tostring(name) .. "' is not a valid walk")
         return
     end
 
-    local walk = RP[name][1]
+    local walk = EmoteData[name][1]
     RequestWalking(walk)
     SetPedMovementClipset(PlayerPedId(), walk, 0.2)
     RemoveAnimSet(walk)
@@ -34,7 +34,7 @@ end
 
 function WalksOnCommand()
     local WalksCommand = ""
-    for name, data in PairsByKeys(RP) do
+    for name, data in PairsByKeys(EmoteData) do
         if type(data) == "table" and data.category == "Walks" then
             WalksCommand = WalksCommand .. string.lower(name) .. ", "
         end
@@ -68,7 +68,7 @@ if Config.WalkingStylesEnabled and Config.PersistentWalk then
             return false
         end
 
-        local walkstyle = RP[kvp]
+        local walkstyle = EmoteData[kvp]
         if walkstyle and type(walkstyle) == "table" and walkstyle.category == "Walks" then
             return true
         end


### PR DESCRIPTION
Introduces a new variable "EmoteData" to hold the converted form of RP. RP is then nil'd to save on the memory it's taking up. Separating the variables improves readability as the two variables already hold different data and I expect their data formats to diverge further in the near future.