### PR TITLE
refactor: conversion code cleanup

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -466,27 +466,29 @@ CreateThread(function()
     local newRP = {}
     for emoteType, content in pairs(RP) do
         for emoteName, emoteData in pairs(content) do
-            local shouldRemove = false
-
-            if Config.AdultEmotesDisabled and emoteData.AdultAnimation then
-                shouldRemove = true
-            end
             if newRP[emoteName] then
-                print('WARNING - Duplicate emote name found: ' .. emoteName .. ' in ' .. emoteType .. ' and ' .. newRP[emoteName].category)
+                print(string.format(
+                    "WARNING - Duplicate emote name found: %s in %s and %s",
+                    emoteName, emoteType, newRP[emoteName].category
+                ))
             end
-            if shouldRemove then
-            elseif type(emoteData) == "table" then
+            if Config.AdultEmotesDisabled and emoteData.AdultAnimation then
+                goto continue
+            end
+
+            if type(emoteData) == "table" then
                 newRP[emoteName] = {}
                 for k, v in pairs(emoteData) do
                     newRP[emoteName][k] = v
                 end
-                newRP[emoteName].category = emoteType
             else
                 newRP[emoteName] = { emoteData }
-                newRP[emoteName].category = emoteType
             end
+
+            newRP[emoteName].category = emoteType
+
+            ::continue::
         end
-        newRP[emoteType] = nil
     end
     RP = newRP
     CONVERTED = true


### PR DESCRIPTION
- Using goto to skip adult emotes
- Using string format rather that string concatenation for formatting the warning
- Removed newRP[emoteType] = nil as newRP never had the emoteType added as a top level key, so this instruction wasn't doing anything
- Moved category setting into shared space since the if chain isn't responsible for filtering anymore.