### PR TITLE
refactor: minor readability improvements

### DIFF
--- a/client/Binoculars.lua
+++ b/client/Binoculars.lua
@@ -32,7 +32,7 @@ if Config.BinocularsEnabled then
         if IsPedSittingInAnyVehicle(PlayerPedId()) then
             return
         end
-        if IsInActionWithErrorMessage({ ['IsUsingBinoculars'] = true }) then
+        if IsInActionWithErrorMessage({ IsUsingBinoculars = true }) then
             return
         end
         IsUsingBinoculars = not IsUsingBinoculars

--- a/client/Bridge.lua
+++ b/client/Bridge.lua
@@ -3,7 +3,7 @@ PlayerLoaded, PlayerData = nil, {}
 
 local function InitializeFramework()
     if GetResourceState('es_extended') == 'started' then
-        ESX = exports['es_extended']:getSharedObject()
+        ESX = exports.es_extended:getSharedObject()
         Framework = 'esx'
 
         RegisterNetEvent('esx:playerLoaded', function(xPlayer)

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -187,11 +187,7 @@ end
 ---@param playerPed number
 ---@return boolean
 local function ShouldPlayerDiveToCrawl(playerPed)
-    if IsPedRunning(playerPed) or IsPedSprinting(playerPed) then
-        return true
-    end
-
-    return false
+    return IsPedRunning(playerPed) or IsPedSprinting(playerPed)
 end
 
 ---Stops the player from being prone
@@ -241,13 +237,13 @@ local function Crawl(playerPed, type, direction)
     TaskPlayAnim(playerPed, 'move_crawl', type..'_'..direction, 8.0, -8.0, -1, 2, 0.0, false, false, false)
 
     local time = {
-        ['onfront'] = {
-            ['fwd'] = 820,
-            ['bwd'] = 990
+        onfront = {
+            fwd = 820,
+            bwd = 990
         },
-        ['onback'] = {
-            ['fwd'] = 1200,
-            ['bwd'] = 1200
+        onback = {
+            fwd = 1200,
+            bwd = 1200
         }
     }
 
@@ -402,7 +398,7 @@ local function CrawlKeyPressed()
         return
     end
 
-    if IsInActionWithErrorMessage({['IsProne'] = true}) then
+    if IsInActionWithErrorMessage({IsProne = true}) then
         return
     end
 

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -160,11 +160,7 @@ function EmoteCancel(force)
 
     if not CanCancel and not force then return end
 
-    if ChosenScenarioType == "MaleScenario" and IsInAnimation then
-        ClearPedTasksImmediately(PlayerPedId())
-        IsInAnimation = false
-        DebugPrint("Forced scenario exit")
-    elseif ChosenScenarioType == "Scenario" and IsInAnimation then
+    if (ChosenScenarioType == "MaleScenario" or ChosenScenarioType == "Scenario") and IsInAnimation then
         ClearPedTasksImmediately(PlayerPedId())
         IsInAnimation = false
         DebugPrint("Forced scenario exit")
@@ -474,12 +470,12 @@ function OnEmotePlay(name, textureVariation)
 
 
     local animOption = emoteData.AnimationOptions
-    if InVehicle then
-        if animOption and animOption.NotInVehicle then
+    if animOption then
+        if InVehicle and animOption.NotInVehicle then
             return EmoteChatMessage(Translate('not_in_a_vehicle'))
+        elseif not InVehicle and animOption.onlyInVehicle then
+            return EmoteChatMessage(Translate('in_a_vehicle'))
         end
-    elseif animOption and animOption.onlyInVehicle then
-        return EmoteChatMessage(Translate('in_a_vehicle'))
     end
 
     if CurrentAnimOptions
@@ -550,7 +546,6 @@ function OnEmotePlay(name, textureVariation)
     end
 
     local movementType = 0
-
     if InVehicle then
         if animOption and animOption.FullBody then
             movementType = 35

--- a/client/NewsCam.lua
+++ b/client/NewsCam.lua
@@ -1,217 +1,80 @@
 IsUsingNewscam = false
+if not Config.NewscamEnabled then return end
 
-if Config.NewscamEnabled then
-    RegisterCommand("newscam", function()
-        UseNewscam()
-    end, false)
+RegisterCommand("newscam", function()
+    UseNewscam()
+end, false)
 
-    TriggerEvent('chat:addSuggestion', '/newscam', 'Use newscam', {})
+TriggerEvent('chat:addSuggestion', '/newscam', 'Use newscam', {})
 
-    local fov = 40.0
-    local index = 0
-    local scaleform_instructions
-    local scaleform_news
-    local prop_newscam
-    local msg = "YOUR TEXT HERE"
-    local bottom = "YOUR TEXT HERE"
-    local title = "YOUR TEXT HERE"
-    local instructions = true
-    local cam
+local fov = 40.0
+local index = 0
+local scaleform_instructions
+local scaleform_news
+local prop_newscam
+local msg = "YOUR TEXT HERE"
+local bottom = "YOUR TEXT HERE"
+local title = "YOUR TEXT HERE"
+local instructions = true
+local cam
 
-    local function CleanupNewscam()
-        ClearPedTasks(PlayerPedId())
-        ClearTimecycleModifier()
-        RenderScriptCams(false, false, 0, true, false)
-        SetScaleformMovieAsNoLongerNeeded(breaking_news)
-        SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
-        DestroyCam(cam, false)
-        if prop_newscam then
-            DeleteEntity(prop_newscam)
-        end
-        SetNightvision(false)
-        SetSeethrough(false)
+local function CleanupNewscam()
+    ClearPedTasks(PlayerPedId())
+    ClearTimecycleModifier()
+    RenderScriptCams(false, false, 0, true, false)
+    SetScaleformMovieAsNoLongerNeeded(breaking_news)
+    SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
+    DestroyCam(cam, false)
+    if prop_newscam then
+        DeleteEntity(prop_newscam)
     end
+    SetNightvision(false)
+    SetSeethrough(false)
+end
 
-    function UseNewscam()
-        if IsPedSittingInAnyVehicle(PlayerPedId()) then
-            return
-        end
-        if IsInActionWithErrorMessage({ ['IsUsingNewscam'] = true }) then
-            return
-        end
-        IsUsingNewscam = not IsUsingNewscam
+function UseNewscam()
+    if IsPedSittingInAnyVehicle(PlayerPedId()) then
+        return
+    end
+    if IsInActionWithErrorMessage({IsUsingNewscam = true }) then
+        return
+    end
+    IsUsingNewscam = not IsUsingNewscam
 
-        if IsUsingNewscam then
-            CreateThread(function()
-                DestroyAllProps()
-                ClearPedTasks(PlayerPedId())
-                RequestAnimDict("missfinale_c2mcs_1")
-                while not HasAnimDictLoaded("missfinale_c2mcs_1") do
-                    Wait(5)
-                end
-
-                -- attach the prop to the player
-                local boneIndex = GetPedBoneIndex(PlayerPedId(), 28422)
-                local x, y, z = table.unpack(GetEntityCoords(PlayerPedId(), true))
-                if not HasModelLoaded("prop_v_cam_01") then
-                    LoadPropDict("prop_v_cam_01")
-                end
-                prop_newscam = CreateObject(`prop_v_cam_01`, x, y, z + 0.2, true, true, true)
-                AttachEntityToEntity(prop_newscam, PlayerPedId(), boneIndex, 0.0, 0.03, 0.01, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
-
-                TaskPlayAnim(PlayerPedId(), "missfinale_c2mcs_1", "fin_c2_mcs_1_camman", 5.0, 5.0, -1, 51, 0, false, false, false)
-                PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
-                SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
-
-                RemoveAnimDict("missfinale_c2mcs_1")
-                SetModelAsNoLongerNeeded("prop_v_cam_01")
-            end)
-
-            Wait(200)
-            SetTimecycleModifier("default")
-            SetTimecycleModifierStrength(0.3)
-            local breaking_news = RequestScaleformMovie("breaking_news")
-            while not HasScaleformMovieLoaded(breaking_news) do
-                Wait(10)
+    if IsUsingNewscam then
+        CreateThread(function()
+            DestroyAllProps()
+            ClearPedTasks(PlayerPedId())
+            RequestAnimDict("missfinale_c2mcs_1")
+            while not HasAnimDictLoaded("missfinale_c2mcs_1") do
+                Wait(5)
             end
 
-
-            PushScaleformMovieFunction(breaking_news, "breaking_news")
-            PopScaleformMovieFunctionVoid()
-
-            BeginScaleformMovieMethod(breaking_news, 'SET_TEXT')
-            PushScaleformMovieMethodParameterString(msg)
-            PushScaleformMovieMethodParameterString(bottom)
-            EndScaleformMovieMethod()
-
-            BeginScaleformMovieMethod(breaking_news, 'SET_SCROLL_TEXT')
-            PushScaleformMovieMethodParameterInt(0) -- top ticker
-            PushScaleformMovieMethodParameterInt(0) -- Since this is the first string, start at 0
-            PushScaleformMovieMethodParameterString(title)
-
-            EndScaleformMovieMethod()
-
-            BeginScaleformMovieMethod(breaking_news, 'DISPLAY_SCROLL_TEXT')
-            PushScaleformMovieMethodParameterInt(0) -- Top ticker
-            PushScaleformMovieMethodParameterInt(0) -- Index of string
-
-            EndScaleformMovieMethod()
-
-            scaleform_news = breaking_news
-
-            cam = CreateCam("DEFAULT_SCRIPTED_FLY_CAMERA", true)
-
-            AttachCamToEntity(cam, PlayerPedId(), 0.0, 0.0, 1.2, true)
-            SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()))
-            SetCamFov(cam, fov)
-            RenderScriptCams(true, false, 0, true, false)
-
-            scaleform_instructions = SetupButtons({
-                { key = 177, text = 'exit_news' },
-                { key = 19,  text = 'toggle_news_vision' },
-                { key = 74,  text = "edit_values_newscam" },
-                { key = 47,  text = 'toggle_instructions' }
-            })
-
-            while IsUsingNewscam and not IsEntityDead(PlayerPedId()) and not IsPedSittingInAnyVehicle(PlayerPedId()) do
-                if IsControlJustPressed(0, 177) then
-                    PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
-                    IsUsingNewscam = false
-                end
-
-                fov = HandleZoomAndCheckRotation(cam, fov)
-
-                HideHUDThisFrame()
-                DisableControlAction(0, 25, true)        -- disable aim
-                DisableControlAction(0, 44, true)        -- INPUT_COVER
-                DisableControlAction(0, 37, true)        -- INPUT_SELECT_WEAPON
-                DisableControlAction(0, 24, true)        -- Attack
-                DisablePlayerFiring(PlayerPedId(), true) -- Disable weapon firing
-
-
-                if IsControlJustPressed(0, 19) then
-                    -- if index = 0, show the "security_camera" scaleform, if index = 1, show the "breaking_news" scaleform and reset the index to 0
-                    if index == 0 then
-                        index = 1
-                        PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
-                        scaleform_news = nil
-                        CreateThread(function()
-                            while index == 1 do
-                                DrawRect(0.0, 0.0, 2.0, 0.2, 0, 0, 0, 255)
-                                DrawRect(0.0, 1.0, 2.0, 0.2, 0, 0, 0, 255)
-                                Wait(1)
-                            end
-                        end)
-                    else
-                        index = 0
-                        PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
-                        scaleform_news = breaking_news
-                    end
-                end
-
-                if IsControlJustPressed(0, 74) then
-                    SetMsgBottomTitle()
-                end
-
-                if IsControlJustPressed(0, 47) then
-                    instructions = not instructions
-                    PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
-                end
-
-                DrawScaleformMovieFullscreen(scaleform_news, 255, 255, 255, 255)
-                if instructions then
-                    DrawScaleformMovieFullscreen(scaleform_instructions, 255, 255, 255, 255)
-                end
-                Wait(1)
+            -- attach the prop to the player
+            local boneIndex = GetPedBoneIndex(PlayerPedId(), 28422)
+            local x, y, z = table.unpack(GetEntityCoords(PlayerPedId(), true))
+            if not HasModelLoaded("prop_v_cam_01") then
+                LoadPropDict("prop_v_cam_01")
             end
-        end
+            prop_newscam = CreateObject(`prop_v_cam_01`, x, y, z + 0.2, true, true, true)
+            AttachEntityToEntity(prop_newscam, PlayerPedId(), boneIndex, 0.0, 0.03, 0.01, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
 
-        -- RESET EVERYTHING
-        IsUsingNewscam = false
-        index = 0
+            TaskPlayAnim(PlayerPedId(), "missfinale_c2mcs_1", "fin_c2_mcs_1_camman", 5.0, 5.0, -1, 51, 0, false, false, false)
+            PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
+            SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
 
-        CleanupNewscam()
-    end
+            RemoveAnimDict("missfinale_c2mcs_1")
+            SetModelAsNoLongerNeeded("prop_v_cam_01")
+        end)
 
-    function SetMsgBottomTitle()
-        -- keyboard input to set the message and bottom title
-        AddTextEntry("top", "Enter the top message of the news")
-        DisplayOnscreenKeyboard(1, "top", "", "", "", "", "", 200)
-        while (UpdateOnscreenKeyboard() == 0) do
-            DisableAllControlActions(0);
-            Wait(0);
-        end
-        if (GetOnscreenKeyboardResult()) then
-            title = tostring(GetOnscreenKeyboardResult())
-        end
-
-        AddTextEntry("bottom", "Enter the bottom title of the news")
-        DisplayOnscreenKeyboard(1, "bottom", "", "", "", "", "", 200)
-        while (UpdateOnscreenKeyboard() == 0) do
-            DisableAllControlActions(0);
-            Wait(0);
-        end
-        if (GetOnscreenKeyboardResult()) then
-            bottom = tostring(GetOnscreenKeyboardResult())
-        end
-
-        AddTextEntry("title", "Enter the title of the news")
-        DisplayOnscreenKeyboard(1, "title", "", "", "", "", "", 200)
-        while (UpdateOnscreenKeyboard() == 0) do
-            DisableAllControlActions(0);
-            Wait(0);
-        end
-        if (GetOnscreenKeyboardResult()) then
-            msg = tostring(GetOnscreenKeyboardResult())
-        end
-
-
-        -- reset the scaleform and set the new values
-        SetScaleformMovieAsNoLongerNeeded(breaking_news)
-        breaking_news = RequestScaleformMovie("breaking_news")
+        Wait(200)
+        SetTimecycleModifier("default")
+        SetTimecycleModifierStrength(0.3)
+        local breaking_news = RequestScaleformMovie("breaking_news")
         while not HasScaleformMovieLoaded(breaking_news) do
             Wait(10)
         end
+
 
         PushScaleformMovieFunction(breaking_news, "breaking_news")
         PopScaleformMovieFunctionVoid()
@@ -225,21 +88,157 @@ if Config.NewscamEnabled then
         PushScaleformMovieMethodParameterInt(0) -- top ticker
         PushScaleformMovieMethodParameterInt(0) -- Since this is the first string, start at 0
         PushScaleformMovieMethodParameterString(title)
+
         EndScaleformMovieMethod()
 
         BeginScaleformMovieMethod(breaking_news, 'DISPLAY_SCROLL_TEXT')
         PushScaleformMovieMethodParameterInt(0) -- Top ticker
         PushScaleformMovieMethodParameterInt(0) -- Index of string
+
         EndScaleformMovieMethod()
+
+        scaleform_news = breaking_news
+
+        cam = CreateCam("DEFAULT_SCRIPTED_FLY_CAMERA", true)
+
+        AttachCamToEntity(cam, PlayerPedId(), 0.0, 0.0, 1.2, true)
+        SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()))
+        SetCamFov(cam, fov)
+        RenderScriptCams(true, false, 0, true, false)
+
+        scaleform_instructions = SetupButtons({
+            { key = 177, text = 'exit_news' },
+            { key = 19,  text = 'toggle_news_vision' },
+            { key = 74,  text = "edit_values_newscam" },
+            { key = 47,  text = 'toggle_instructions' }
+        })
+
+        while IsUsingNewscam and not IsEntityDead(PlayerPedId()) and not IsPedSittingInAnyVehicle(PlayerPedId()) do
+            if IsControlJustPressed(0, 177) then
+                PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
+                IsUsingNewscam = false
+            end
+
+            fov = HandleZoomAndCheckRotation(cam, fov)
+
+            HideHUDThisFrame()
+            DisableControlAction(0, 25, true)        -- disable aim
+            DisableControlAction(0, 44, true)        -- INPUT_COVER
+            DisableControlAction(0, 37, true)        -- INPUT_SELECT_WEAPON
+            DisableControlAction(0, 24, true)        -- Attack
+            DisablePlayerFiring(PlayerPedId(), true) -- Disable weapon firing
+
+
+            if IsControlJustPressed(0, 19) then
+                -- if index = 0, show the "security_camera" scaleform, if index = 1, show the "breaking_news" scaleform and reset the index to 0
+                if index == 0 then
+                    index = 1
+                    PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
+                    scaleform_news = nil
+                    CreateThread(function()
+                        while index == 1 do
+                            DrawRect(0.0, 0.0, 2.0, 0.2, 0, 0, 0, 255)
+                            DrawRect(0.0, 1.0, 2.0, 0.2, 0, 0, 0, 255)
+                            Wait(1)
+                        end
+                    end)
+                else
+                    index = 0
+                    PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
+                    scaleform_news = breaking_news
+                end
+            end
+
+            if IsControlJustPressed(0, 74) then
+                SetMsgBottomTitle()
+            end
+
+            if IsControlJustPressed(0, 47) then
+                instructions = not instructions
+                PlaySoundFrontend(-1, "SELECT", "HUD_FRONTEND_DEFAULT_SOUNDSET", false)
+            end
+
+            DrawScaleformMovieFullscreen(scaleform_news, 255, 255, 255, 255)
+            if instructions then
+                DrawScaleformMovieFullscreen(scaleform_instructions, 255, 255, 255, 255)
+            end
+            Wait(1)
+        end
     end
 
-    AddEventHandler('onResourceStop', function(resource)
-        if resource == GetCurrentResourceName() then
-            CleanupNewscam()
-        end
-    end)
+    -- RESET EVERYTHING
+    IsUsingNewscam = false
+    index = 0
 
-    CreateExport('toggleNewscam', function()
-        UseNewscam()
-    end)
+    CleanupNewscam()
 end
+
+function SetMsgBottomTitle()
+    -- keyboard input to set the message and bottom title
+    AddTextEntry("top", "Enter the top message of the news")
+    DisplayOnscreenKeyboard(1, "top", "", "", "", "", "", 200)
+    while (UpdateOnscreenKeyboard() == 0) do
+        DisableAllControlActions(0);
+        Wait(0);
+    end
+    if (GetOnscreenKeyboardResult()) then
+        title = tostring(GetOnscreenKeyboardResult())
+    end
+
+    AddTextEntry("bottom", "Enter the bottom title of the news")
+    DisplayOnscreenKeyboard(1, "bottom", "", "", "", "", "", 200)
+    while (UpdateOnscreenKeyboard() == 0) do
+        DisableAllControlActions(0);
+        Wait(0);
+    end
+    if (GetOnscreenKeyboardResult()) then
+        bottom = tostring(GetOnscreenKeyboardResult())
+    end
+
+    AddTextEntry("title", "Enter the title of the news")
+    DisplayOnscreenKeyboard(1, "title", "", "", "", "", "", 200)
+    while (UpdateOnscreenKeyboard() == 0) do
+        DisableAllControlActions(0);
+        Wait(0);
+    end
+    if (GetOnscreenKeyboardResult()) then
+        msg = tostring(GetOnscreenKeyboardResult())
+    end
+
+
+    -- reset the scaleform and set the new values
+    SetScaleformMovieAsNoLongerNeeded(breaking_news)
+    breaking_news = RequestScaleformMovie("breaking_news")
+    while not HasScaleformMovieLoaded(breaking_news) do
+        Wait(10)
+    end
+
+    PushScaleformMovieFunction(breaking_news, "breaking_news")
+    PopScaleformMovieFunctionVoid()
+
+    BeginScaleformMovieMethod(breaking_news, 'SET_TEXT')
+    PushScaleformMovieMethodParameterString(msg)
+    PushScaleformMovieMethodParameterString(bottom)
+    EndScaleformMovieMethod()
+
+    BeginScaleformMovieMethod(breaking_news, 'SET_SCROLL_TEXT')
+    PushScaleformMovieMethodParameterInt(0) -- top ticker
+    PushScaleformMovieMethodParameterInt(0) -- Since this is the first string, start at 0
+    PushScaleformMovieMethodParameterString(title)
+    EndScaleformMovieMethod()
+
+    BeginScaleformMovieMethod(breaking_news, 'DISPLAY_SCROLL_TEXT')
+    PushScaleformMovieMethodParameterInt(0) -- Top ticker
+    PushScaleformMovieMethodParameterInt(0) -- Index of string
+    EndScaleformMovieMethod()
+end
+
+AddEventHandler('onResourceStop', function(resource)
+    if resource == GetCurrentResourceName() then
+        CleanupNewscam()
+    end
+end)
+
+CreateExport('toggleNewscam', function()
+    UseNewscam()
+end)

--- a/client/Pointing.lua
+++ b/client/Pointing.lua
@@ -7,11 +7,14 @@ end
 local function CanPlayerPoint()
     local playerPed = PlayerPedId()
     local playerId = PlayerId()
-    if not DoesEntityExist(playerPed) or IsPedOnAnyBike(playerPed) or IsPlayerAiming(playerId) or IsPedFalling(playerPed) or IsPedInjured(playerPed) or IsPedInMeleeCombat(playerPed) or IsPedRagdoll(playerPed) or not IsPedHuman(playerPed) then
-        return false
-    end
-
-    return true
+    return DoesEntityExist(playerPed)
+        and IsPedHuman(playerPed)
+        and not IsPedOnAnyBike(playerPed)
+        and not IsPlayerAiming(playerId)
+        and not IsPedFalling(playerPed)
+        and not IsPedInjured(playerPed)
+        and not IsPedInMeleeCombat(playerPed)
+        and not IsPedRagdoll(playerPed)
 end
 
 local function PointingStopped()

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -35,11 +35,12 @@ function IsPlayerAiming(player)
 end
 
 function CanPlayerCrouchCrawl(playerPed)
-    if not IsPedOnFoot(playerPed) or IsPedJumping(playerPed) or IsPedFalling(playerPed) or IsPedInjured(playerPed) or IsPedInMeleeCombat(playerPed) or IsPedRagdoll(playerPed) then
-        return false
-    end
-
-    return true
+    return IsPedOnFoot(playerPed)
+        and not IsPedJumping(playerPed)
+        and not IsPedFalling(playerPed)
+        and not IsPedInjured(playerPed)
+        and not IsPedInMeleeCombat(playerPed)
+        and not IsPedRagdoll(playerPed)
 end
 
 function PlayAnimOnce(playerPed, animDict, animName, blendInSpeed, blendOutSpeed, duration, startTime)
@@ -192,24 +193,24 @@ end
 
 -- Function that'll check if player is already proning, using news cam or else
 
----@param ignores? table | nil key string is the ignored value
+---@param ignores? table key string is the ignored value
 function IsInActionWithErrorMessage(ignores)
     if ignores then DebugPrint(ignores) end
     DebugPrint('IsProne', IsProne)
     DebugPrint('IsUsingNewscam', IsUsingNewscam)
     DebugPrint('IsUsingBinoculars', IsUsingBinoculars)
-    if (ignores == nil) then ignores = {} end
+    if ignores == nil then ignores = {} end
 
-    if not ignores['IsProne'] and IsProne then
+    if not ignores.IsProne and IsProne then
         EmoteChatMessage(Translate('no_anim_crawling'))
         return true
     end
-    if not ignores['IsUsingNewscam'] and IsUsingNewscam then
+    if not ignores.IsUsingNewscam and IsUsingNewscam then
         -- TODO: use specific error message
         EmoteChatMessage(Translate('no_anim_right_now'))
         return true
     end
-    if not ignores['IsUsingBinoculars'] and IsUsingBinoculars then
+    if not ignores.IsUsingBinoculars and IsUsingBinoculars then
         -- TODO: use specific error message
         EmoteChatMessage(Translate('no_anim_right_now'))
         return true

--- a/client/Walk.lua
+++ b/client/Walk.lua
@@ -70,22 +70,17 @@ if Config.WalkingStylesEnabled and Config.PersistentWalk then
         end
 
         local walkstyle = EmoteData[kvp]
-        if walkstyle and type(walkstyle) == "table" and walkstyle.category == "Walks" then
-            return true
-        end
-        return false
+        return walkstyle and type(walkstyle) == "table" and walkstyle.category == "Walks"
     end
 
     local function handleWalkstyle()
         local kvp = GetResourceKvpString("walkstyle")
-
-        if kvp then
-            if walkstyleExists(kvp) then
-                WalkMenuStart(kvp, true)
-            else
-                ResetPedMovementClipset(PlayerPedId(), 0.0)
-                DeleteResourceKvp("walkstyle")
-            end
+        if not kvp then return end
+        if walkstyleExists(kvp) then
+            WalkMenuStart(kvp, true)
+        else
+            ResetPedMovementClipset(PlayerPedId(), 0.0)
+            DeleteResourceKvp("walkstyle")
         end
     end
 


### PR DESCRIPTION
- replace logic instances of string table deference with dot object notation myTable['key'] -> myTable.key
- Made Newscam config check a guard clause to reduce indentation in that file
- Replaced instances of if someCondition then return true else return false with return someCondition. In some cases I inverted the condition if it was written as if someCondition then return false else return true
- A few other miscellaneous improvements (use of a guard clause, removing unnecessary parentheses)