### PR TITLE
refactor: Use enum for anim flag options

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Below is an example of how this would look:
         "sit_phone_phoneputdown_idle_nowork",
         "Sit",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },

--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -632,7 +632,7 @@ RP.Shared = {
         "Handshake",
         "handshake2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000,
             SyncOffsetFront = 0.9
         }
@@ -643,7 +643,7 @@ RP.Shared = {
         "Handshake 2",
         "handshake",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -653,7 +653,6 @@ RP.Shared = {
         "Hug",
         "hug2",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 5000,
             SyncOffsetFront = 1.05
         }
@@ -664,7 +663,6 @@ RP.Shared = {
         "Hug 2",
         "hug",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 5000,
             SyncOffsetFront = 1.18
         }
@@ -675,8 +673,7 @@ RP.Shared = {
         "Hug Romantic 1",
         "hugr2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             SyncOffsetSide = -0.05,
             SyncOffsetFront = 0.52
         }
@@ -687,8 +684,7 @@ RP.Shared = {
         "Hug Romantic 2",
         "hugr",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             SyncOffsetSide = -0.05,
             SyncOffsetFront = 0.52
         }
@@ -717,7 +713,7 @@ RP.Shared = {
         "Give",
         "give2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -727,7 +723,7 @@ RP.Shared = {
         "Give 2",
         "give",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -749,8 +745,7 @@ RP.Shared = {
         "Stick Up",
         "stickupscared",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["stickupscared"] = {
@@ -759,8 +754,7 @@ RP.Shared = {
         "Stickup Scared",
         "stickup",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["punch"] = {
@@ -793,8 +787,7 @@ RP.Shared = {
         "Slap 2",
         "slapped2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -804,8 +797,7 @@ RP.Shared = {
         "Slap",
         "slapped",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -827,8 +819,7 @@ RP.Shared = {
         "Carry",
         "carry2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carry2"] = {
@@ -837,8 +828,7 @@ RP.Shared = {
         "Be carried",
         "carry",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 40269,
             xPos = -0.14,
@@ -855,8 +845,7 @@ RP.Shared = {
         "Carry 2",
         "carry4",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carry4"] = {
@@ -865,8 +854,7 @@ RP.Shared = {
         "Be carried 2",
         "carry3",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 28252,
             xPos = 0.350,
@@ -883,8 +871,7 @@ RP.Shared = {
         "Carry Me Cute",
         "carrymecute2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carrymecute2"] = { -- Female Custom emote by Amnilka
@@ -893,8 +880,7 @@ RP.Shared = {
         "Carry Me Cute 2",
         "carrymecute",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0000,
@@ -911,8 +897,7 @@ RP.Shared = {
         "Carry Me Cute 3",
         "carrycmg2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["carrycmg2"] = { -- Female Custom emote by CMG Mods
@@ -921,7 +906,7 @@ RP.Shared = {
         "Carry Me Cute 4",
         "carrycmg",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0100,
@@ -938,8 +923,7 @@ RP.Shared = {
     "Best Friends 1",
     "bestfriends2",
     AnimationOptions = {
-        EmoteMoving = false,
-        EmoteLoop = true
+        onFootFlag = AnimFlag.LOOP
         }
     },
     ["bestfriends2"] = { -- Female Custom emote by MrWitt
@@ -948,8 +932,7 @@ RP.Shared = {
     "Best Friends 2",
     "bestfriends",
     AnimationOptions = {
-        EmoteMoving = false,
-        EmoteLoop = true,
+        onFootFlag = AnimFlag.LOOP,
         Attachto = true,
         bone = 0,
         xPos = -0.2500,
@@ -966,8 +949,7 @@ RP.Shared = {
         "BFF Pose",
         "bffb",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
     },
     ["bffb"] = {
@@ -976,8 +958,7 @@ RP.Shared = {
         "BFF Pose 2",
         "bff",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0100,
@@ -994,8 +975,7 @@ RP.Shared = {
         "Sit With Me",
         "sitwithmepose2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["sitwithmepose2"] = { -- Female Custom emote by Amnilka
@@ -1004,8 +984,7 @@ RP.Shared = {
         "Sit With Me Please?",
         "sitwithmepose",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.3540,
@@ -1022,8 +1001,7 @@ RP.Shared = {
         "Hug Pose",
         "hugpose2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["hugpose2"] = { -- Female Custom emote by Amnilka
@@ -1032,8 +1010,7 @@ RP.Shared = {
         "Hug Pose With Me?",
         "hugpose",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.1400,
@@ -1050,8 +1027,7 @@ RP.Shared = {
         "Hug Pose Tippy Toes",
         "hugtip2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["hugtip2"] = { -- Female Custom emote by Little Spoon
@@ -1060,8 +1036,7 @@ RP.Shared = {
         "Hug Pose Tippy Toes 2",
         "hugtip",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0100,
@@ -1078,8 +1053,7 @@ RP.Shared = {
         "Cute Pic Pose",
         "cutepicpose2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["cutepicpose2"] = { -- Female Custom emote by Amnilka
@@ -1088,8 +1062,7 @@ RP.Shared = {
         "Cute Pic Pose 2",
         "cutepicpose",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.2700,
@@ -1106,8 +1079,7 @@ RP.Shared = {
         "Couple Heart Hands",
         "couplehhands2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["couplehhands2"] = { -- Female Custom emote by Amnilka
@@ -1116,8 +1088,7 @@ RP.Shared = {
         "Couple Heart Hands 2",
         "couplehhands",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = -0.1230,
@@ -1134,8 +1105,7 @@ RP.Shared = {
         "Couple Wedding Pose 1A",
         "couplewed1b",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["couplewed1b"] = { -- Female Custom emote by EnchantedBrwny
@@ -1144,8 +1114,7 @@ RP.Shared = {
         "Couple Wedding Pose 1B",
         "couplewed1a",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0300,
@@ -1162,8 +1131,7 @@ RP.Shared = {
         "Couple Wedding Pose 2A",
         "couplewed2b",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["couplewed2b"] = { -- Female Custom emote by EnchantedBrwny
@@ -1172,8 +1140,7 @@ RP.Shared = {
         "Couple Wedding Pose 2B",
         "couplewed2a",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0100,
@@ -1190,7 +1157,7 @@ RP.Shared = {
         "Lift Me",
         "liftme2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["liftme2"] = { -- Female Custom emote by -Moses-
@@ -1199,8 +1166,7 @@ RP.Shared = {
         "Lift Me 2",
         "liftme",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0020,
@@ -1217,8 +1183,7 @@ RP.Shared = {
         "Lift Me 3",
         "liftme4",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["liftme4"] = { -- Female Custom emote by -Moses-
@@ -1227,8 +1192,7 @@ RP.Shared = {
         "Lift Me 4",
         "liftme3",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0100,
@@ -1245,7 +1209,7 @@ RP.Shared = {
         "Lift Me 5",
         "liftme6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["liftme6"] = { -- Female Custom emote by -Moses-
@@ -1254,8 +1218,7 @@ RP.Shared = {
         "Lift Me 6",
         "liftme5",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = -0.2120,
@@ -1272,8 +1235,7 @@ RP.Shared = {
         "Carry Small Dog",
         "csdog2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AnimalEmote = true
     },
@@ -1283,8 +1245,7 @@ RP.Shared = {
         "Small Dog Carried",
         "csdog",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = -0.040,
             yPos = 0.330,
@@ -1301,8 +1262,7 @@ RP.Shared = {
         "Carry Small Dog 2",
         "csdog4",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AnimalEmote = true
     },
@@ -1312,8 +1272,7 @@ RP.Shared = {
         "Small Dog Carried 2",
         "csdog3",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 24818,
             xPos = -0.95,
@@ -1331,8 +1290,7 @@ RP.Shared = {
         "Carry Big Dog",
         "cbdog2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AnimalEmote = true
     },
@@ -1342,8 +1300,7 @@ RP.Shared = {
         "Big Dog Carried",
         "cbdog",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = -0.100,
             yPos = 0.650,
@@ -1360,8 +1317,7 @@ RP.Shared = {
         "Offer Piggy Back",
         "pback2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pback2"] = { -- Custom Animation By SapphireMods
@@ -1370,8 +1326,7 @@ RP.Shared = {
         "Be Piggy Backed",
         "pback",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.0200,
@@ -1388,7 +1343,7 @@ RP.Shared = {
         "Give CPR",
         "cprs2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 250
         }
     },
@@ -1398,7 +1353,7 @@ RP.Shared = {
         "Get CPR",
         "cprs",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = 0.35,
             yPos = 0.8,
@@ -1414,7 +1369,7 @@ RP.Shared = {
         "Give CPR 2",
         "cprs4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 250
         }
     },
@@ -1424,7 +1379,7 @@ RP.Shared = {
         "Get CPR 2",
         "cprs3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = 0.35,
             yPos = 0.65,
@@ -1440,8 +1395,7 @@ RP.Shared = {
         "Take hostage",
         "hostage2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["hostage2"] = {
@@ -1450,7 +1404,7 @@ RP.Shared = {
         "Be hostage",
         "hostage",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = -0.3,
             yPos = 0.1,
@@ -1466,8 +1420,7 @@ RP.Shared = {
         "Search",
         "search2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = false,
+            onFootFlag = AnimFlag.MOVING,
             -- EmoteDuration = 9700
         }
     },
@@ -1477,8 +1430,7 @@ RP.Shared = {
         "Be searched",
         "search",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = false,
+            onFootFlag = AnimFlag.MOVING,
             -- EmoteDuration = 9700,
             Attachto = true,
             xPos = 0.0,
@@ -1495,8 +1447,7 @@ RP.Shared = {
         "Follow A (Front)",
         "followb",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             -- We can set this to true for lols, however it messes up if you walk through doors. Either player can press X to cancel the shared emotes
         }
     },
@@ -1506,7 +1457,7 @@ RP.Shared = {
         "Follow B (Back)",
         "followa",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             xPos = 0.078,
             yPos = 0.018,
@@ -1522,7 +1473,6 @@ RP.Shared = {
         "Kiss",
         "kiss2",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 10000,
             SyncOffsetFront = 0.08
         }
@@ -1533,7 +1483,6 @@ RP.Shared = {
         "Kiss 2",
         "kiss",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 10000,
             SyncOffsetFront = 0.08
         }
@@ -1544,7 +1493,6 @@ RP.Shared = {
         "Kiss 3",
         "kiss4",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 10000,
             SyncOffsetFront = 0.08
         }
@@ -1555,7 +1503,6 @@ RP.Shared = {
         "Kiss 4",
         "kiss3",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 10000,
             SyncOffsetFront = 0.08
         }
@@ -1566,8 +1513,7 @@ RP.Shared = {
         "Kiss Cute - Neck (Male)",
         "kisscuteneck2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             --SyncOffsetFront = 0.05,
             --bone = 0,
@@ -1586,8 +1532,7 @@ RP.Shared = {
         "Kiss Cute - Neck (Female)",
         "kisscuteneck",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             --SyncOffsetFront = 0.05,
 
         }
@@ -1598,8 +1543,7 @@ RP.Shared = {
         "Kiss Cute Cheek (Male)",
         "kisscutecheek2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             --SyncOffsetFront = 0.05,
             --bone = 0,
@@ -1618,8 +1562,7 @@ RP.Shared = {
         "Kiss Cute Cheek (Female)",
         "kisscutecheek",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             --SyncOffsetFront = 0.05,
 
         }
@@ -1630,8 +1573,7 @@ RP.Shared = {
         "Kiss Forehead (Male)",
         "kisscutefh2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             --SyncOffsetFront = 0.05,
             --bone = 0,
@@ -1650,8 +1592,7 @@ RP.Shared = {
         "Kiss Cute Lips (Female)",
         "kisslips2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = 0.1600,
@@ -1669,8 +1610,7 @@ RP.Shared = {
         "Kiss Cute Lips (Male)",
         "kisslips",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
 
         }
     },
@@ -1680,8 +1620,7 @@ RP.Shared = {
         "Kiss Forehead (Female)",
         "kisscutefh",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             --SyncOffsetFront = 0.05,
 
         }
@@ -1702,8 +1641,7 @@ RP.Shared = {
                 0.0,
                 0.0,
             },
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["coupleanim2"] = {
@@ -1724,8 +1662,7 @@ RP.Shared = {
             },
             SyncOffsetSide = -0.04125,
             SyncOffsetFront = 0.11,
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["holdme"] = { -- Custom Animation By SapphireMods
@@ -1734,7 +1671,7 @@ RP.Shared = {
         "Hold Me",
         "holdmeb",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
     },
     ["holdmeb"] = { -- Custom Animation By SapphireMods
@@ -1743,8 +1680,7 @@ RP.Shared = {
         "Be Held",
         "holdme",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = -0.0200,
@@ -1761,7 +1697,7 @@ RP.Shared = {
         "Hold Me 2",
         "holdmed",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
     },
     ["holdmed"] = { -- Custom Animation By SapphireMods
@@ -1770,8 +1706,7 @@ RP.Shared = {
         "Be Held 2",
         "holdmec",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos = -0.1200,
@@ -1788,7 +1723,7 @@ RP.Shared = {
         "Hold Me 3",
         "holdmef",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["holdmef"] = { -- Custom Animation By SapphireMods
@@ -1797,8 +1732,7 @@ RP.Shared = {
         "Be Held 3",
         "holdmee",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Attachto = true,
             bone = 0,
             xPos =  0.0400,
@@ -1819,7 +1753,7 @@ RP.Dances = {
         "hi_dance_facedj_17_v2_male^5",
         "Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance2"] = {
@@ -1827,7 +1761,7 @@ RP.Dances = {
         "high_center_down",
         "Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance3"] = {
@@ -1835,7 +1769,7 @@ RP.Dances = {
         "high_center",
         "Dance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance4"] = {
@@ -1843,7 +1777,7 @@ RP.Dances = {
         "high_center_up",
         "Dance 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance5"] = {
@@ -1851,7 +1785,7 @@ RP.Dances = {
         "med_center",
         "Dance 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance6"] = {
@@ -1859,7 +1793,7 @@ RP.Dances = {
         "dance_loop_tao",
         "Dance 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance7"] = {
@@ -1867,7 +1801,7 @@ RP.Dances = {
         "dance_loop_tao",
         "Dance 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance8"] = {
@@ -1875,7 +1809,7 @@ RP.Dances = {
         "dance_m_default",
         "Dance 8",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dance9"] = {
@@ -1883,7 +1817,7 @@ RP.Dances = {
         "med_center_up",
         "Dance 9",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef"] = {
@@ -1891,7 +1825,7 @@ RP.Dances = {
         "mi_dance_facedj_17_v1_female^1",
         "Dance F",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef2"] = {
@@ -1899,7 +1833,7 @@ RP.Dances = {
         "high_center",
         "Dance F2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef3"] = {
@@ -1907,7 +1841,7 @@ RP.Dances = {
         "high_center_up",
         "Dance F3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef4"] = {
@@ -1915,7 +1849,7 @@ RP.Dances = {
         "hi_dance_facedj_09_v2_female^1",
         "Dance F4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef5"] = {
@@ -1923,7 +1857,7 @@ RP.Dances = {
         "hi_dance_facedj_09_v2_female^3",
         "Dance F5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancef6"] = {
@@ -1931,7 +1865,7 @@ RP.Dances = {
         "high_center_up",
         "Dance F6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclub"] = {
@@ -1939,7 +1873,7 @@ RP.Dances = {
         "hi_idle_a_m03",
         "Dance Club",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubb"] = {
@@ -1947,7 +1881,7 @@ RP.Dances = {
         "hi_idle_a_m05",
         "Dance Club 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubc"] = {
@@ -1955,7 +1889,7 @@ RP.Dances = {
         "hi_idle_a_m02",
         "Dance Club 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubd"] = {
@@ -1963,7 +1897,7 @@ RP.Dances = {
         "hi_idle_b_f01",
         "Dance Club 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclube"] = {
@@ -1971,7 +1905,7 @@ RP.Dances = {
         "hi_idle_a_f02",
         "Dance Club 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubf"] = {
@@ -1979,7 +1913,7 @@ RP.Dances = {
         "hi_idle_b_m03",
         "Dance Club 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubg"] = {
@@ -1987,7 +1921,7 @@ RP.Dances = {
         "hi_idle_d_f01",
         "Dance Club 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubh"] = {
@@ -1995,7 +1929,7 @@ RP.Dances = {
         "mi_dance_facedj_17_v2_male^4",
         "Dance Club 8",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubi"] = {
@@ -2003,7 +1937,7 @@ RP.Dances = {
         "mi_dance_prop_13_v1_male^3",
         "Dance Club 9",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubj"] = {
@@ -2011,7 +1945,7 @@ RP.Dances = {
         "mi_dance_crowd_13_v2_male^1",
         "Dance Club 10",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubk"] = {
@@ -2019,7 +1953,7 @@ RP.Dances = {
         "mi_dance_facedj_15_v2_male^4",
         "Dance Club 11",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubl"] = {
@@ -2027,7 +1961,7 @@ RP.Dances = {
         "high_center_up",
         "Dance Club 12",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubm"] = {
@@ -2035,7 +1969,7 @@ RP.Dances = {
         "hi_dance_facedj_hu_15_v2_male^5",
         "Dance Club 13",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubn"] = {
@@ -2043,7 +1977,7 @@ RP.Dances = {
         "hi_dance_facedj_hu_17_male^5",
         "Dance Club 14",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubo"] = {
@@ -2051,7 +1985,7 @@ RP.Dances = {
         "high_center",
         "Dance Club 15",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubp"] = {
@@ -2059,7 +1993,7 @@ RP.Dances = {
         "high_left_down",
         "Dance Club 16",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceclubq"] = {
@@ -2067,7 +2001,7 @@ RP.Dances = {
         "a_f_y_studioparty_01_dual-25",
         "Dance Club 17",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancedrink"] = {
@@ -2085,8 +2019,7 @@ RP.Dances = {
                 0.0,
                 20.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink2"] = {
@@ -2104,8 +2037,7 @@ RP.Dances = {
                 0.0,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink3"] = {
@@ -2123,8 +2055,7 @@ RP.Dances = {
                 0.0,
                 10.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink4"] = {
@@ -2142,8 +2073,7 @@ RP.Dances = {
                 0.0,
                 10.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink5"] = {
@@ -2161,8 +2091,7 @@ RP.Dances = {
                 0.0,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink6"] = {
@@ -2180,8 +2109,7 @@ RP.Dances = {
                 180.0,
                 -69.99
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink7"] = {
@@ -2199,8 +2127,7 @@ RP.Dances = {
                 0.0,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink8"] = {
@@ -2218,8 +2145,7 @@ RP.Dances = {
                 0.0,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancedrink9"] = {
@@ -2237,8 +2163,7 @@ RP.Dances = {
                 0.0,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["danceslow2"] = {
@@ -2246,7 +2171,7 @@ RP.Dances = {
         "low_center",
         "Dance Slow 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceslow3"] = {
@@ -2254,7 +2179,7 @@ RP.Dances = {
         "low_center_down",
         "Dance Slow 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceslow4"] = {
@@ -2262,7 +2187,7 @@ RP.Dances = {
         "low_center",
         "Dance Slow 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceupper"] = {
@@ -2270,8 +2195,7 @@ RP.Dances = {
         "high_center",
         "Dance Upper",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["danceupper2"] = {
@@ -2279,8 +2203,7 @@ RP.Dances = {
         "high_center_up",
         "Dance Upper 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["danceshy"] = {
@@ -2288,7 +2211,7 @@ RP.Dances = {
         "low_center",
         "Dance Shy",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceshy2"] = {
@@ -2296,7 +2219,7 @@ RP.Dances = {
         "low_center_down",
         "Dance Shy 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceslow"] = {
@@ -2304,7 +2227,7 @@ RP.Dances = {
         "low_center",
         "Dance Slow",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly1"] = {
@@ -2312,7 +2235,7 @@ RP.Dances = {
         "dance_loop_tyler",
         "Dance Silly 1",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly"] = {
@@ -2320,7 +2243,7 @@ RP.Dances = {
         "mnt_dnc_buttwag",
         "Dance Silly",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly2"] = {
@@ -2328,7 +2251,7 @@ RP.Dances = {
         "fidget_short_dance",
         "Dance Silly 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly3"] = {
@@ -2336,7 +2259,7 @@ RP.Dances = {
         "fidget_short_dance",
         "Dance Silly 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly4"] = {
@@ -2344,7 +2267,7 @@ RP.Dances = {
         "danceidle_hi_11_buttwiggle_b_laz",
         "Dance Silly 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly5"] = {
@@ -2352,7 +2275,7 @@ RP.Dances = {
         "idle_a",
         "Dance Silly 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly6"] = {
@@ -2360,7 +2283,7 @@ RP.Dances = {
         "idle_d",
         "Dance Silly 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly7"] = {
@@ -2368,7 +2291,7 @@ RP.Dances = {
         "med_center",
         "Dance Silly 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly8"] = {
@@ -2376,7 +2299,7 @@ RP.Dances = {
         "high_center",
         "Dance Silly 8",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly9"] = {
@@ -2384,7 +2307,7 @@ RP.Dances = {
         "the_woogie",
         "Dance Silly 9",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly10"] = {
@@ -2392,7 +2315,7 @@ RP.Dances = {
         "danceidle_hi_17_spiderman_laz",
         "Dance Silly 10",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancesilly11"] = {
@@ -2400,7 +2323,7 @@ RP.Dances = {
         "danceidle_mi_11_pointthrust_laz",
         "Dance Silly 11",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceold"] = {
@@ -2408,8 +2331,8 @@ RP.Dances = {
         "idle_a",
         "Dance Old",
         AnimationOptions = {
-            EmoteLoop = true,
-            --			EmoteMoving = true,-- Removing the comment will allow for you to mix and match dance emotes, ie /e danceold and /e dance to control the bottom half of the body.
+            onFootFlag = AnimFlag.LOOP,
+            --			onFootFlag = AnimFlag.MOVING,-- Removing the comment will allow for you to mix and match dance emotes, ie /e danceold and /e dance to control the bottom half of the body.
         }
     },
     ["danceglowstick"] = {
@@ -2435,8 +2358,7 @@ RP.Dances = {
                 -120.0,
                 -20.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["danceglowstick2"] = {
@@ -2462,7 +2384,7 @@ RP.Dances = {
                 -120.0,
                 -20.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["danceglowstick3"] = {
@@ -2488,7 +2410,7 @@ RP.Dances = {
                 -120.0,
                 -20.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancehorse"] = {
@@ -2506,8 +2428,7 @@ RP.Dances = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["dancehorse2"] = {
@@ -2525,7 +2446,7 @@ RP.Dances = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancehorse3"] = {
@@ -2543,7 +2464,7 @@ RP.Dances = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave"] = { -- Custom Emote By BoringNeptune
@@ -2551,7 +2472,7 @@ RP.Dances = {
         "wave_dance_1",
         "Wave Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave02"] = { -- Custom Emote By BoringNeptune
@@ -2559,7 +2480,7 @@ RP.Dances = {
         "wave_dance_2",
         "Wave Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave03"] = { -- Custom Emote By BoringNeptune
@@ -2567,7 +2488,7 @@ RP.Dances = {
         "wave_dance_3",
         "Wave Dance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave04"] = { -- Custom Emote By BoringNeptune
@@ -2575,7 +2496,7 @@ RP.Dances = {
         "wave_dance_4",
         "Wave Dance 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave05"] = { -- Custom Emote By BoringNeptune
@@ -2583,7 +2504,7 @@ RP.Dances = {
         "tutankhamun_dance_1",
         "Wave Dance 5 - Tutankhamen",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave06"] = { -- Custom Emote By BoringNeptune
@@ -2591,7 +2512,7 @@ RP.Dances = {
         "tutankhamun_dance_2",
         "Wave Dance 6 - Tutankhamen 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave07"] = { -- Custom Emote By BoringNeptune
@@ -2599,7 +2520,7 @@ RP.Dances = {
         "snake_dance_1",
         "Wave Dance 7 - Snake Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave08"] = { -- Custom Emote By BoringNeptune
@@ -2607,7 +2528,7 @@ RP.Dances = {
         "slide_dance",
         "Wave Dance 8 - Slide Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave09"] = { -- Custom Emote By BoringNeptune
@@ -2615,7 +2536,7 @@ RP.Dances = {
         "slide_dance_2",
         "Wave Dance 9 - Slide Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave10"] = { -- Custom Emote By BoringNeptune
@@ -2623,7 +2544,7 @@ RP.Dances = {
         "robot_dance",
         "Wave Dance 10 - Robot Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave11"] = { -- Custom Emote By BoringNeptune
@@ -2631,39 +2552,30 @@ RP.Dances = {
         "locking_dance",
         "Wave Dance 11 - Locking Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancewave12"] = { -- Custom Emote By BoringNeptune
         "dancing_wave_part_one@anim",
         "headspin",
         "Wave Dance 12 - Headspin",
-        AnimationOptions = {
-            EmoteLoop = false
-        }
     },
     ["dancewave13"] = { -- Custom Emote By BoringNeptune
         "dancing_wave_part_one@anim",
         "flaire_dance",
         "Wave Dance 13 - Flaire Dance",
-        AnimationOptions = {
-            EmoteLoop = false
-        }
     },
     ["dancewave14"] = { -- Custom Emote By BoringNeptune
         "dancing_wave_part_one@anim",
         "crowd_girl_dance",
         "Wave Dance 14 - Female Crowd Dance",
-        AnimationOptions = {
-            EmoteLoop = false
-        }
     },
     ["dancewave15"] = { -- Custom Emote By BoringNeptune
         "dancing_wave_part_one@anim",
         "uprock_dance_1",
         "Wave Dance 15 - Uprock Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancethriller"] = { -- Custom Emote By BoringNeptune
@@ -2671,7 +2583,7 @@ RP.Dances = {
         "mj_thriller_dance",
         "Dance - MJ Thriller",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dj"] = {
@@ -2679,8 +2591,7 @@ RP.Dances = {
         "dixn_dance_cntr_open_dix",
         "DJ",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dj2"] = {
@@ -2688,8 +2599,7 @@ RP.Dances = {
         "sol_idle_ctr_mid_a_sol",
         "DJ 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj3"] = {
@@ -2697,8 +2607,7 @@ RP.Dances = {
         "sol_dance_l_sol",
         "DJ 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj4"] = {
@@ -2706,8 +2615,7 @@ RP.Dances = {
         "dance_b_idle_a_blamadon",
         "DJ 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj1"] = {
@@ -2715,8 +2623,7 @@ RP.Dances = {
         "dixn_end_dix",
         "DJ 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj5"] = {
@@ -2724,8 +2631,7 @@ RP.Dances = {
         "dixn_idle_cntr_a_dix",
         "DJ 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj6"] = {
@@ -2733,8 +2639,7 @@ RP.Dances = {
         "dixn_idle_cntr_b_dix",
         "DJ 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj7"] = {
@@ -2742,8 +2647,7 @@ RP.Dances = {
         "dixn_idle_cntr_g_dix",
         "DJ 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj8"] = {
@@ -2751,8 +2655,7 @@ RP.Dances = {
         "dixn_idle_cntr_gb_dix",
         "DJ 8",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dj9"] = {
@@ -2760,8 +2663,7 @@ RP.Dances = {
         "dixn_sync_cntr_j_dix",
         "DJ 9",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["twerk"] = {
@@ -2769,7 +2671,7 @@ RP.Dances = {
         "001443_01_trvs_28_idle_stripper",
         "Twerk",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdance"] = {
@@ -2782,7 +2684,7 @@ RP.Dances = {
         "priv_dance_idle",
         "Lapdance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdance3"] = {
@@ -2790,7 +2692,7 @@ RP.Dances = {
         "priv_dance_p1",
         "Lapdance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdance4"] = {
@@ -2798,7 +2700,7 @@ RP.Dances = {
         "priv_dance_p2",
         "Lapdance 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdance5"] = {
@@ -2806,7 +2708,7 @@ RP.Dances = {
         "priv_dance_p3",
         "Lapdance 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdance6"] = {
@@ -2814,7 +2716,7 @@ RP.Dances = {
         "yacht_ld_f",
         "Lapdance 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdancewith"] = {
@@ -2822,7 +2724,7 @@ RP.Dances = {
         "ld_2g_p3_s2",
         "Lapdance With",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdancewith2"] = {
@@ -2830,7 +2732,7 @@ RP.Dances = {
         "ld_2g_p2_s2",
         "Lapdance With2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapdancewith3"] = {
@@ -2838,7 +2740,7 @@ RP.Dances = {
         "ld_2g_p1_s2",
         "Lapdance With3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapchair"] = {
@@ -2846,7 +2748,7 @@ RP.Dances = {
         "ld_girl_a_song_a_p1_f",
         "Lap Chair",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapchair2"] = {
@@ -2854,7 +2756,7 @@ RP.Dances = {
         "ld_girl_a_song_a_p2_f",
         "Lap Chair2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lapchair3"] = {
@@ -2862,7 +2764,7 @@ RP.Dances = {
         "ld_girl_a_song_a_p3_f",
         "Lap Chair3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["salsa"] = {
@@ -2870,7 +2772,7 @@ RP.Dances = {
         "idle_a",
         "Salso Roll",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancecrankdat"] = {
@@ -2878,7 +2780,7 @@ RP.Dances = {
         "high_right_up",
         "Dance Crank Dat",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancecrankdat2"] = {
@@ -2886,7 +2788,7 @@ RP.Dances = {
         "high_right_down",
         "Dance Crank Dat 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancemonkey"] = {
@@ -2894,7 +2796,7 @@ RP.Dances = {
         "high_center",
         "Monkey Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancemonkey2"] = {
@@ -2902,7 +2804,7 @@ RP.Dances = {
         "high_center_down",
         "Monkey Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancemonkey3"] = {
@@ -2910,7 +2812,7 @@ RP.Dances = {
         "med_center_down",
         "Monkey Dance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["boxdance"] = {
@@ -2918,7 +2820,7 @@ RP.Dances = {
         "med_right_down",
         "Boxing Dance Solo",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancehiphop"] = {
@@ -2926,7 +2828,7 @@ RP.Dances = {
         "ped_a_dance_idle",
         "Hip Hop Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancehiphop2"] = {
@@ -2934,7 +2836,7 @@ RP.Dances = {
         "ped_a_dance_idle",
         "Hip Hop Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancehiphop3"] = {
@@ -2942,7 +2844,7 @@ RP.Dances = {
         "ped_a_dance_idle",
         "Hip Hop Dance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dancedrill"] = {
@@ -2950,8 +2852,7 @@ RP.Dances = {
         "sdrill_clip",
         "Drill Dance",
         AnimationOptions = {
-            EmoteLoop = true,
-			EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancepride"] = {
@@ -2979,8 +2880,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["danceprideb"] = {
@@ -3008,8 +2908,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancepridea"] = {
@@ -3037,8 +2936,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancepridec"] = {
@@ -3066,8 +2964,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["danceprided"] = {
@@ -3095,8 +2992,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancepridee"] = {
@@ -3124,8 +3020,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dancepridef"] = {
@@ -3153,8 +3048,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["danceprideg"] = {
@@ -3182,8 +3076,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["danceprideh"] = {
@@ -3211,8 +3104,7 @@ RP.Dances = {
                 5.7068,
                 -28.7797
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["technodance"] = {
@@ -3220,7 +3112,7 @@ RP.Dances = {
         "high_left_up",
         "Techno Dance",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["technodance2"] = {
@@ -3228,7 +3120,7 @@ RP.Dances = {
         "med_center_up",
         "Techno Dance 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["technodance3"] = {
@@ -3236,7 +3128,7 @@ RP.Dances = {
         "high_left",
         "Techno Dance 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["technodance4"] = {
@@ -3244,7 +3136,7 @@ RP.Dances = {
         "high_right_up",
         "Techno Dance 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 }
@@ -3259,7 +3151,7 @@ RP.AnimalEmotes = {
         "idle_a",
         "Bark (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogindicateahead"] = {
@@ -3267,7 +3159,7 @@ RP.AnimalEmotes = {
         "indicate_ahead",
         "Indicate Ahead (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogindicatehigh"] = {
@@ -3275,7 +3167,7 @@ RP.AnimalEmotes = {
         "indicate_high",
         "Indicate High (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogindicatelow"] = {
@@ -3283,7 +3175,7 @@ RP.AnimalEmotes = {
         "indicate_low",
         "Indicate Low (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogbeg"] = {
@@ -3291,7 +3183,7 @@ RP.AnimalEmotes = {
         "beg_loop",
         "Beg (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogbeg2"] = {
@@ -3299,7 +3191,7 @@ RP.AnimalEmotes = {
         "paw_right_loop",
         "Beg 2 (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdoglayright"] = {
@@ -3307,7 +3199,7 @@ RP.AnimalEmotes = {
         "dead_right",
         "Lay Right (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdoglayleft"] = {
@@ -3315,7 +3207,7 @@ RP.AnimalEmotes = {
         "dead_left",
         "Lay Left (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogsitcar"] = {
@@ -3323,7 +3215,7 @@ RP.AnimalEmotes = {
         "sit",
         "Sit in car (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bdogfhump"] = {
@@ -3331,7 +3223,7 @@ RP.AnimalEmotes = {
         "hump_loop_ladydog",
         "Female Hump (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true,
         AnimalEmote = true
@@ -3341,7 +3233,7 @@ RP.AnimalEmotes = {
         "hump_loop_chop",
         "Male Hump (big dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true,
         AnimalEmote = true
@@ -3351,8 +3243,7 @@ RP.AnimalEmotes = {
         "dump_loop",
         "Shit (big dog)",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_poo",
             PtfxNoProp = true,
@@ -3383,7 +3274,7 @@ RP.AnimalEmotes = {
         "sleep_in_kennel",
         "Sleep (big dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogupk",
         }
     },
@@ -3392,7 +3283,7 @@ RP.AnimalEmotes = {
         "base",
         "Sit (big dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3401,7 +3292,7 @@ RP.AnimalEmotes = {
         "pee_left_idle",
         "Pee (big dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -3424,7 +3315,7 @@ RP.AnimalEmotes = {
         "pee_right_idle",
         "Pee 2 (big dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -3457,8 +3348,7 @@ RP.AnimalEmotes = {
                 0.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bdogglowb"] = {
@@ -3476,7 +3366,7 @@ RP.AnimalEmotes = {
                 0.00,
                 0.00
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3505,7 +3395,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3534,7 +3424,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3563,7 +3453,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3592,7 +3482,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3621,7 +3511,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3650,7 +3540,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3679,7 +3569,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3708,7 +3598,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3737,7 +3627,7 @@ RP.AnimalEmotes = {
                 -90.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "bdogup",
         }
     },
@@ -3757,8 +3647,7 @@ RP.AnimalEmotes = {
                 -176.7400,
                 -9.8767
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_indep_fireworks",
             PtfxName = "scr_indep_firework_trail_spawn",
             PtfxPlacement = {
@@ -3789,8 +3678,7 @@ RP.AnimalEmotes = {
                -169.4149,
                 21.4173
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 
@@ -3802,7 +3690,7 @@ RP.AnimalEmotes = {
         "idle_a",
         "Bark (small dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["sdogitch"] = {
@@ -3810,7 +3698,7 @@ RP.AnimalEmotes = {
         "idle_a",
         "Itch (small dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -3819,7 +3707,7 @@ RP.AnimalEmotes = {
         "idle_b",
         "Sit (small dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -3828,7 +3716,7 @@ RP.AnimalEmotes = {
         "base",
         "Lay Down (small dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -3837,7 +3725,7 @@ RP.AnimalEmotes = {
         "idle_c",
         "Shake (small dog)",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["sdogdance"] = {
@@ -3854,8 +3742,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdance2"] = {
@@ -3882,8 +3769,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdancepridea"] = {
@@ -3911,8 +3797,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdanceprideb"] = {
@@ -3940,8 +3825,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdancepridec"] = {
@@ -3969,8 +3853,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdanceprided"] = {
@@ -3998,8 +3881,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdancepridee"] = {
@@ -4027,8 +3909,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdancepridef"] = {
@@ -4056,8 +3937,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdanceprideg"] = {
@@ -4085,8 +3965,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdanceprideh"] = {
@@ -4114,8 +3993,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdancepridei"] = {
@@ -4143,8 +4021,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogbb"] = {
@@ -4161,8 +4038,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogburger"] = {
@@ -4179,8 +4055,7 @@ RP.AnimalEmotes = {
                 -90.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogcontroller"] = {
@@ -4198,8 +4073,7 @@ RP.AnimalEmotes = {
                 90.0000,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdolla"] = {
@@ -4217,8 +4091,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 0.000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdolla2"] = {
@@ -4236,8 +4109,7 @@ RP.AnimalEmotes = {
                 00.0000,
                 00.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdolla3"] = {
@@ -4255,8 +4127,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 0.000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogdolla4"] = {
@@ -4274,8 +4145,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogmic"] = {
@@ -4293,8 +4163,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogteddy"] = {
@@ -4312,8 +4181,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogteddy2"] = {
@@ -4331,7 +4199,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4350,8 +4218,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogtennisr"] = {
@@ -4369,8 +4236,7 @@ RP.AnimalEmotes = {
                 0.0000,
                 -28.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogrose"] = {
@@ -4388,8 +4254,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogrose2"] = {
@@ -4407,7 +4272,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4426,8 +4291,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoggun2"] = {
@@ -4445,7 +4309,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4464,8 +4328,7 @@ RP.AnimalEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "core",
             PtfxName = "blood_stungun",
             PtfxPlacement = {
@@ -4496,8 +4359,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoggl2"] = {
@@ -4515,7 +4377,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4534,8 +4396,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoggl4"] = {
@@ -4553,7 +4414,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4572,8 +4433,7 @@ RP.AnimalEmotes = {
                 -9.8465858,
                 -0.1488562
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoghd2"] = {
@@ -4591,7 +4451,7 @@ RP.AnimalEmotes = {
                 -9.8465858,
                 -0.1488562
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4610,8 +4470,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoghlmt2"] = {
@@ -4629,8 +4488,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoghat"] = {
@@ -4658,8 +4516,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdoghat2"] = {
@@ -4687,7 +4544,7 @@ RP.AnimalEmotes = {
                 90.00,
                 0.00
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4706,8 +4563,7 @@ RP.AnimalEmotes = {
                 0.00,
                 0.00
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogsteak2"] = {
@@ -4725,7 +4581,7 @@ RP.AnimalEmotes = {
                 0.00,
                 0.00
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4744,8 +4600,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogprideb"] = {
@@ -4763,8 +4618,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogpridec"] = {
@@ -4782,8 +4636,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogprided"] = {
@@ -4801,8 +4654,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogpridee"] = {
@@ -4820,8 +4672,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogpridef"] = {
@@ -4839,8 +4690,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogprideg"] = {
@@ -4858,8 +4708,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogprideh"] = {
@@ -4877,8 +4726,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogpridei"] = {
@@ -4896,8 +4744,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sdogpridesita"] = {
@@ -4915,7 +4762,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4934,7 +4781,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4953,7 +4800,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4972,7 +4819,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -4991,7 +4838,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -5010,7 +4857,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -5029,7 +4876,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -5049,7 +4896,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -5068,7 +4915,7 @@ RP.AnimalEmotes = {
                 0.0,
                 -74.6999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "sdogup",
         }
     },
@@ -5077,7 +4924,7 @@ RP.AnimalEmotes = {
         "nill",
         "Pee (Small Dog)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -5100,8 +4947,7 @@ RP.AnimalEmotes = {
         "nill",
         "Shit (Small Dog)",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_poo",
             PtfxNoProp = true,
@@ -5136,8 +4982,7 @@ RP.AnimalEmotes = {
                -180.0,
                 44.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_indep_fireworks",
             PtfxName = "scr_indep_firework_trail_spawn",
             PtfxPlacement = {
@@ -5168,8 +5013,7 @@ RP.AnimalEmotes = {
               120.0000,
                 0.000,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 }
@@ -5246,7 +5090,7 @@ RP.Exits = {
         AnimationOptions = {
             EmoteDuration = 1780,
             StartDelay = 1150,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["breakfreefont"] = {
@@ -5256,7 +5100,7 @@ RP.Exits = {
         AnimationOptions = {
             EmoteDuration = 6099,
             StartDelay = 450,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["breakfreeback"] = {
@@ -5266,7 +5110,7 @@ RP.Exits = {
         AnimationOptions = {
             EmoteDuration = 6099,
             StartDelay = 450,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["shakeitoffhuman"] = {
@@ -5276,7 +5120,7 @@ RP.Exits = {
         AnimationOptions = {
             EmoteDuration = 2899,
             StartDelay = 850,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
 ------ ANIMAL EXIT EMOTES  ------
@@ -5529,7 +5373,7 @@ RP.Emotes = {
         "Annoyed",
         AnimationOptions =
         {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dispenser"] = {
@@ -5538,7 +5382,6 @@ RP.Emotes = {
         "Dispenser",
         AnimationOptions =
         {
-            EmoteLoop = false
         }
     },
     ["cuffedfront"] = {
@@ -5546,8 +5389,7 @@ RP.Emotes = {
         "idle",
         "Handcuffed - Front",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "breakfreefont",
         }
     },
@@ -5556,8 +5398,7 @@ RP.Emotes = {
         "idle",
         "Handcuffed - Back",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "breakfreeback",
         }
     },
@@ -5566,7 +5407,7 @@ RP.Emotes = {
         "pose1_clip",
         "Dazzle Me Pose 1",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle2"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5574,7 +5415,7 @@ RP.Emotes = {
         "pose2_clip",
         "Dazzle Me Pose 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle3"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5582,7 +5423,7 @@ RP.Emotes = {
         "pose3_clip",
         "Dazzle Me Pose 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle4"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5590,7 +5431,7 @@ RP.Emotes = {
         "pose4_clip",
         "Dazzle Me Pose 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle5"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5598,7 +5439,7 @@ RP.Emotes = {
         "pose5_clip",
         "Dazzle Me Pose 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle6"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5606,7 +5447,7 @@ RP.Emotes = {
         "pose6_clip",
         "Dazzle Me Pose 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["dazzle7"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5614,7 +5455,7 @@ RP.Emotes = {
         "pose7_clip",
         "Dazzle Me Pose 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["dead2"] = {
@@ -5622,7 +5463,6 @@ RP.Emotes = {
         "enter",
         "Play Dead Act",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["femalestandcute"] = {
@@ -5630,8 +5470,7 @@ RP.Emotes = {
         "stand_cute_6_clip",
         "Female Stand Cute Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalestandcute1"] = {
@@ -5639,8 +5478,7 @@ RP.Emotes = {
         "stand_fem_1_clip",
         "Female Stand Cute Pose 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalestandcute2"] = {
@@ -5648,8 +5486,7 @@ RP.Emotes = {
         "feet_stand_w_clip",
         "Female Stand Cute Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalestandcute3"] = {
@@ -5657,8 +5494,7 @@ RP.Emotes = {
         "f_model_14_clip",
         "Female Stand Cute Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalestandcutefinger"] = {
@@ -5666,8 +5502,7 @@ RP.Emotes = {
         "f_model_15_clip",
         "Female Stand Cute Pose Finger",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalestandcute4"] = {
@@ -5675,8 +5510,7 @@ RP.Emotes = {
         "f_model_17_clip",
         "Female Stand Cute Pose 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malestandpose"] = {
@@ -5684,8 +5518,7 @@ RP.Emotes = {
         "m_model_11_clip",
         "Male Stand Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femalesitcute"] = {
@@ -5693,8 +5526,7 @@ RP.Emotes = {
         "sit_cute_1_clip",
         "Female Sit Cute",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -5703,8 +5535,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Sit Cute 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -5713,8 +5544,7 @@ RP.Emotes = {
         "beach_1_clip",
         "Female Sit Cute 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -5723,8 +5553,7 @@ RP.Emotes = {
         "beach_4_clip",
         "Female On Knees Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "standup",
         }
     },
@@ -5733,8 +5562,7 @@ RP.Emotes = {
         "on_the_knees_clip",
         "Female On Knees Pose 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "standup",
         }
     },
@@ -5743,8 +5571,7 @@ RP.Emotes = {
         "f_model_21_clip",
         "Female On Knees Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -5753,7 +5580,7 @@ RP.Emotes = {
         "chic",
         "Fashion Pose Pose 1",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose2"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5761,7 +5588,7 @@ RP.Emotes = {
         "deathdrop",
         "Fashion Pose Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "standup",
         }
     },
@@ -5770,7 +5597,7 @@ RP.Emotes = {
         "magica",
         "Fashion Pose Pose 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose4"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5778,7 +5605,7 @@ RP.Emotes = {
         "pose5",
         "Fashion Pose Pose 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose5"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5786,7 +5613,7 @@ RP.Emotes = {
         "pose8",
         "Fashion Pose Pose 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose6"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5794,7 +5621,7 @@ RP.Emotes = {
         "pose20",
         "Fashion Pose Pose 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose7"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5802,7 +5629,7 @@ RP.Emotes = {
         "pose28",
         "Fashion Pose Pose 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose8"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5810,7 +5637,7 @@ RP.Emotes = {
         "runoutofposes",
         "Fashion Pose Pose 8",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["fashionpose9"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -5818,7 +5645,7 @@ RP.Emotes = {
         "split",
         "Fashion Pose Pose 9",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "standup",
         }
     },
@@ -5827,7 +5654,7 @@ RP.Emotes = {
         "beast_transform",
         "Beast",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 5000
         }
     },
@@ -5836,7 +5663,7 @@ RP.Emotes = {
         "trev_scares_tramp_idle_tramp",
         "Chill",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 200,
             ExitEmote = "getup",
         }
@@ -5846,7 +5673,7 @@ RP.Emotes = {
         "trev_annoys_sunbathers_loop_girl",
         "Cloudgaze",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -5856,7 +5683,7 @@ RP.Emotes = {
         "trev_annoys_sunbathers_loop_guy",
         "Cloudgaze 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -5866,7 +5693,7 @@ RP.Emotes = {
         "lean_back_idle",
         "Crouch & Reach",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
         }
     },
@@ -5875,7 +5702,7 @@ RP.Emotes = {
         "line_5_dax",
         "Crouch & Reach 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
         }
     },
@@ -5884,8 +5711,7 @@ RP.Emotes = {
         "girl_groupe_d_clip",
         "Daydream In The Clouds",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["khands"] = { -- Custom Emote By EnchantedBrwny
@@ -5893,8 +5719,7 @@ RP.Emotes = {
         "ebrwny_hrt000",
         "Korean Hand Hearts 🇰🇷",
         AnimationOptions = {
-			EmoteLoop = true,
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
         }
     },
 	["uwu2"] = { -- Custom Emote By EnchantedBrwny
@@ -5902,8 +5727,7 @@ RP.Emotes = {
         "ebrwny_shy",
         "UwU 2",
         AnimationOptions = {
-			EmoteLoop = true,
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
         }
     },
     ["rawr"] = { -- Custom Emote By EnchantedBrwny
@@ -5911,8 +5735,7 @@ RP.Emotes = {
         "ebrwny_rawr",
         "Rawr",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stop"] = { -- Custom Emote By EnchantedBrwny
@@ -5920,8 +5743,7 @@ RP.Emotes = {
         "ebrwny_stop",
         "Stop",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sassy"] = { -- Custom Emote By EnchantedBrwny
@@ -5929,8 +5751,7 @@ RP.Emotes = {
         "ebrwny_sass",
         "Sassy",
         AnimationOptions = {
-			EmoteLoop = true,
-            EmoteMoving = true
+			onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sitsad3"] = { -- Custom Emote By EnchantedBrwny
@@ -5938,7 +5759,7 @@ RP.Emotes = {
         "ebrwny_sitf000",
         "Sit Sad 3",
         AnimationOptions = {
-			EmoteLoop = true,
+			onFootFlag = AnimFlag.LOOP,
 			ExitEmote = "getup",
         }
     },
@@ -5948,7 +5769,7 @@ RP.Emotes = {
         "Sit Sad 4",
         AnimationOptions = {
 			StartDelay = 600,
-			EmoteLoop = true,
+			onFootFlag = AnimFlag.LOOP,
 			ExitEmote = "getup",
         }
     },
@@ -5958,8 +5779,7 @@ RP.Emotes = {
         "Bend over",
         AnimationOptions = {
 			StartDelay = 600,
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             NotInVehicle = true
         }
     },
@@ -5968,7 +5788,7 @@ RP.Emotes = {
         "prone_dave",
         "Prone",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -5978,7 +5798,7 @@ RP.Emotes = {
         "pull_over_right",
         "Pullover",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1300
         }
     },
@@ -5987,7 +5807,7 @@ RP.Emotes = {
         "idle",
         "Idle",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle8"] = {
@@ -6000,7 +5820,7 @@ RP.Emotes = {
         "base_idle",
         "Idle 9",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle10"] = {
@@ -6008,8 +5828,7 @@ RP.Emotes = {
         "idle",
         "Idle 10",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["idle11"] = {
@@ -6017,7 +5836,7 @@ RP.Emotes = {
         "idle_a",
         "Idle 11",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle12"] = {
@@ -6025,7 +5844,7 @@ RP.Emotes = {
         "base",
         "Idle 12",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle13"] = {
@@ -6033,7 +5852,7 @@ RP.Emotes = {
         "base",
         "Idle 13",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle14"] = {
@@ -6041,7 +5860,7 @@ RP.Emotes = {
         "idle_a",
         "Idle 14",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle15"] = {
@@ -6049,7 +5868,7 @@ RP.Emotes = {
         "female_hold_arm@_base_base",
         "Idle 15",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle16"] = {
@@ -6057,7 +5876,7 @@ RP.Emotes = {
         "ped_female@_stand@_02a@_base_base",
         "Idle 16",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle17"] = {
@@ -6065,7 +5884,7 @@ RP.Emotes = {
         "amb_world_human_hang_out_street_female_hold_arm_idle_b",
         "Idle 17",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle18"] = {
@@ -6073,7 +5892,7 @@ RP.Emotes = {
         "idle",
         "Idle 18",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle19"] = {
@@ -6081,7 +5900,7 @@ RP.Emotes = {
         "base_4",
         "Idle 19",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle2"] = {
@@ -6089,7 +5908,7 @@ RP.Emotes = {
         "idle",
         "Idle 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle3"] = {
@@ -6097,7 +5916,7 @@ RP.Emotes = {
         "ped_b_celebrate_loop",
         "Idle 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle4"] = {
@@ -6105,7 +5924,7 @@ RP.Emotes = {
         "celebration_idle_f_a",
         "Idle 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle5"] = {
@@ -6113,7 +5932,7 @@ RP.Emotes = {
         "idle_a",
         "Idle 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle6"] = {
@@ -6121,7 +5940,7 @@ RP.Emotes = {
         "idle_a",
         "Idle 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idle7"] = {
@@ -6129,7 +5948,7 @@ RP.Emotes = {
         "idle_a",
         "Idle 7",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idledrunk"] = {
@@ -6137,7 +5956,7 @@ RP.Emotes = {
         "drunk_driver_stand_loop_dd1",
         "Idle Drunk",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idledrunk2"] = {
@@ -6145,7 +5964,7 @@ RP.Emotes = {
         "drunk_driver_stand_loop_dd2",
         "Idle Drunk 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["idledrunk3"] = {
@@ -6153,7 +5972,7 @@ RP.Emotes = {
         "standing_idle_loop_drunk",
         "Idle Drunk 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["impatient2"] = {
@@ -6161,7 +5980,7 @@ RP.Emotes = {
         "f_impatient_b",
         "impatient 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["airguitar"] = {
@@ -6179,8 +5998,7 @@ RP.Emotes = {
         "actor_berating_loop",
         "Argue",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["argue2"] = {
@@ -6188,8 +6006,7 @@ RP.Emotes = {
         "argue_a",
         "Argue 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["argue3"] = {
@@ -6197,8 +6014,7 @@ RP.Emotes = {
         "lsdh_ig_1_argue_wade",
         "Argue 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["argue4"] = {
@@ -6207,7 +6023,7 @@ RP.Emotes = {
         "Argue 4",
         AnimationOptions = {
             EmoteDuration = 6000,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["argue5"] = {
@@ -6215,8 +6031,7 @@ RP.Emotes = {
         "arguement_loop_mp_m_brawler_01",
         "Argue Angry 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["argue6"] = {
@@ -6224,8 +6039,7 @@ RP.Emotes = {
         "arguement_loop_mp_m_brawler_02",
         "Argue Angry 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bartender"] = {
@@ -6233,8 +6047,7 @@ RP.Emotes = {
         "idle_a_bartender",
         "Bartender",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["blowkiss"] = {
@@ -6247,7 +6060,7 @@ RP.Emotes = {
         "exit",
         "Blow Kiss 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -6261,7 +6074,7 @@ RP.Emotes = {
         "bring_it_on",
         "Bring It On",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -6270,7 +6083,7 @@ RP.Emotes = {
         "want_some_of_this",
         "Come at me bro",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -6279,7 +6092,7 @@ RP.Emotes = {
         "rcmme_amanda1_stand_loop_cop",
         "Cop 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["cop3"] = {
@@ -6287,7 +6100,7 @@ RP.Emotes = {
         "idle_b",
         "Cop 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["crossarms"] = {
@@ -6295,8 +6108,7 @@ RP.Emotes = {
         "idle_a",
         "Crossarms",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms2"] = {
@@ -6304,7 +6116,7 @@ RP.Emotes = {
         "idle_b",
         "Crossarms 2",
         AnimationOptions = {
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["crossarms3"] = {
@@ -6312,8 +6124,7 @@ RP.Emotes = {
         "single_team_loop_boss",
         "Crossarms 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms4"] = {
@@ -6321,8 +6132,7 @@ RP.Emotes = {
         "_car_b_lookout",
         "Crossarms 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms5"] = {
@@ -6330,8 +6140,7 @@ RP.Emotes = {
         "rcmme_amanda1_stand_loop_cop",
         "Crossarms 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms6"] = {
@@ -6339,8 +6148,7 @@ RP.Emotes = {
         "_idle",
         "Crossarms 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms7"] = {
@@ -6348,8 +6156,7 @@ RP.Emotes = {
         "female_arms_crossed@_base_base",
         "Crossarms 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms8"] = {
@@ -6357,8 +6164,7 @@ RP.Emotes = {
         "ped_female@_stand@_03b@_base_base",
         "Crossarms 8",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarms9"] = {
@@ -6366,8 +6172,7 @@ RP.Emotes = {
         "a_f_y_vinewood_02_dual-4",
         "Crossarms 9",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["foldarms"] = {
@@ -6375,8 +6180,7 @@ RP.Emotes = {
         "stand_phone_phoneputdown_idle_nowork",
         "Fold Arms",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foldarms2"] = {
@@ -6384,8 +6188,7 @@ RP.Emotes = {
         "rcmme_amanda1_stand_loop_cop",
         "Fold Arms 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarmsside"] = {
@@ -6393,8 +6196,7 @@ RP.Emotes = {
         "base_m2",
         "Crossarms Side",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["crossarmsside2"] = {
@@ -6402,8 +6204,7 @@ RP.Emotes = {
         "base",
         "Crossarms Side 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["damn"] = {
@@ -6411,7 +6212,7 @@ RP.Emotes = {
         "gesture_damn",
         "Damn",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -6420,7 +6221,7 @@ RP.Emotes = {
         "shoplift_mid",
         "Damn 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -6429,7 +6230,7 @@ RP.Emotes = {
         "gesture_hand_down",
         "Point Down",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -6438,7 +6239,7 @@ RP.Emotes = {
         "a_m_y_carclub_01^3_dual-47",
         "Point Down",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["surrender"] = {
@@ -6446,7 +6247,7 @@ RP.Emotes = {
         "idle_a",
         "Surrender",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "surrender_exit",
         }
     },
@@ -6455,7 +6256,7 @@ RP.Emotes = {
         "f_cower_02",
         "Surrender 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -6464,7 +6265,7 @@ RP.Emotes = {
         "m_cower_01",
         "Surrender 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -6473,7 +6274,7 @@ RP.Emotes = {
         "m_cower_02",
         "Surrender 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -6482,7 +6283,7 @@ RP.Emotes = {
         "kneeling_arrest_idle",
         "Surrender 5",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "surrender_exit",
         }
     },
@@ -6491,7 +6292,7 @@ RP.Emotes = {
         "m_cower_01",
         "Surrender 6",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -6500,7 +6301,7 @@ RP.Emotes = {
         "on_knee_idle_a",
         "Surrender 7",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -6509,7 +6310,7 @@ RP.Emotes = {
         "face_palm",
         "Facepalm 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 8000
         }
     },
@@ -6518,7 +6319,7 @@ RP.Emotes = {
         "agitated_idle_a",
         "Facepalm",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 8000
         }
     },
@@ -6527,7 +6328,7 @@ RP.Emotes = {
         "tasered_2",
         "Facepalm 3",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 8000
         }
     },
@@ -6536,8 +6337,7 @@ RP.Emotes = {
         "idle_a",
         "Facepalm 4",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["fallover"] = {
@@ -6570,8 +6370,7 @@ RP.Emotes = {
         "sleep_loop",
         "Fall Asleep",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["fallasleep2"] = {
@@ -6579,8 +6378,7 @@ RP.Emotes = {
         "sleep_loopfemale",
         "Fall Asleep 2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["fightme"] = {
@@ -6598,8 +6396,7 @@ RP.Emotes = {
         "idle_a",
         "Finger",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["finger2"] = {
@@ -6607,8 +6404,7 @@ RP.Emotes = {
         "idle_a_fp",
         "Finger 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["solo_handshake"] = {
@@ -6616,7 +6412,7 @@ RP.Emotes = {
         "handshake_guy_a",
         "Handshake",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -6625,7 +6421,7 @@ RP.Emotes = {
         "handshake_guy_b",
         "Handshake 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -6634,8 +6430,7 @@ RP.Emotes = {
         "_idle_a",
         "Wait",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait2"] = {
@@ -6643,8 +6438,7 @@ RP.Emotes = {
         "wait_for_van_c",
         "Wait 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait3"] = {
@@ -6652,8 +6446,7 @@ RP.Emotes = {
         "idle_a",
         "Wait 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait4"] = {
@@ -6661,8 +6454,7 @@ RP.Emotes = {
         "idle_a",
         "Wait 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait5"] = {
@@ -6670,8 +6462,7 @@ RP.Emotes = {
         "idle_storeclerk",
         "Wait 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait6"] = {
@@ -6679,8 +6470,7 @@ RP.Emotes = {
         "ig_2_base_amanda",
         "Wait 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait7"] = {
@@ -6688,8 +6478,7 @@ RP.Emotes = {
         "base",
         "Wait 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait8"] = {
@@ -6697,8 +6486,7 @@ RP.Emotes = {
         "idle",
         "Wait 8",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait9"] = {
@@ -6706,8 +6494,7 @@ RP.Emotes = {
         "josh_2_intp1_base",
         "Wait 9",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait10"] = {
@@ -6715,8 +6502,7 @@ RP.Emotes = {
         "ig_3_base_tracy",
         "Wait 10",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait11"] = {
@@ -6724,8 +6510,7 @@ RP.Emotes = {
         "keeper_base",
         "Wait 11",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait12"] = {
@@ -6733,8 +6518,7 @@ RP.Emotes = {
         "keeper_base",
         "Wait 12",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wait13"] = {
@@ -6742,8 +6526,7 @@ RP.Emotes = {
         "base",
         "Wait 13",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["hiking"] = {
@@ -6751,8 +6534,7 @@ RP.Emotes = {
         "idle",
         "Hiking",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["hugme"] = {
@@ -6785,7 +6567,7 @@ RP.Emotes = {
         "jazz_hands",
         "Jazzhands",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 6000
         }
     },
@@ -6794,8 +6576,7 @@ RP.Emotes = {
         "idle_a",
         "Jog 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["jog3"] = {
@@ -6803,8 +6584,7 @@ RP.Emotes = {
         "idle_a",
         "Jog 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["jog4"] = {
@@ -6812,8 +6592,7 @@ RP.Emotes = {
         "idle_a",
         "Jog 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["jog5"] = {
@@ -6821,8 +6600,7 @@ RP.Emotes = {
         "walk",
         "Jog 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["jumpingjacks"] = {
@@ -6830,7 +6608,7 @@ RP.Emotes = {
         "jimmy_getknocked",
         "Jumping Jacks",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneel2"] = {
@@ -6838,7 +6616,7 @@ RP.Emotes = {
         "idle",
         "Kneel 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneel3"] = {
@@ -6846,7 +6624,7 @@ RP.Emotes = {
         "idle_a",
         "Kneel 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneel4"] = {
@@ -6854,7 +6632,7 @@ RP.Emotes = {
         "rest",
         "Kneel 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneel5"] = {
@@ -6862,7 +6640,7 @@ RP.Emotes = {
         "rest",
         "Kneel 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneelhide"] = {
@@ -6870,7 +6648,7 @@ RP.Emotes = {
         "hiding_kneel",
         "Kneel Hide",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kneelthot"] = {
@@ -6878,7 +6656,7 @@ RP.Emotes = {
         "kylie_insta_clip",
         "Kneel Thot Instagram",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 200,
             ExitEmote = "standup",
         }
@@ -6888,7 +6666,7 @@ RP.Emotes = {
         "duo17_clip",
         "Kneel Bored Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 200,
             ExitEmote = "standup",
         }
@@ -6898,7 +6676,7 @@ RP.Emotes = {
         "duo18_clip",
         "Kneel Peace Sign Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 200,
             ExitEmote = "standup",
         }
@@ -6908,7 +6686,7 @@ RP.Emotes = {
         "male_duo_a_clip",
         "Shoe Kick Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 240
         }
    },
@@ -6917,8 +6695,7 @@ RP.Emotes = {
         "couple_singing_m_clip",
         "Rap / Sing",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["squatgunpose"] = { -- Custom Emote By Darks Animations
@@ -6926,7 +6703,7 @@ RP.Emotes = {
         "ganggirls_pose1_clip",
         "Squat Gun Pose - Left",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["squatgunpose3"] = { -- Custom Emote By Darks Animations
@@ -6934,7 +6711,7 @@ RP.Emotes = {
         "gun_prime_2_clip",
         "Squat Gun Pose 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["knock"] = {
@@ -6942,8 +6719,7 @@ RP.Emotes = {
         "knockdoor_idle",
         "Knock",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["knock2"] = {
@@ -6951,7 +6727,7 @@ RP.Emotes = {
         "lift_fibagent_loop",
         "Knock 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["knucklecrunch"] = {
@@ -6959,8 +6735,7 @@ RP.Emotes = {
         "knuckle_crunch",
         "Knuckle Crunch",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lean2"] = {
@@ -6968,7 +6743,7 @@ RP.Emotes = {
         "idle_a",
         "Lean 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lean3"] = {
@@ -6976,7 +6751,7 @@ RP.Emotes = {
         "idle_a",
         "Lean 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lean4"] = {
@@ -6984,7 +6759,7 @@ RP.Emotes = {
         "idle_a",
         "Lean 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lean5"] = {
@@ -6992,7 +6767,7 @@ RP.Emotes = {
         "idle_e",
         "Lean 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lean6"] = {
@@ -7000,7 +6775,7 @@ RP.Emotes = {
         "lean_wall_idle_03_lamar",
         "Lean 6",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["leanflirt"] = {
@@ -7008,7 +6783,7 @@ RP.Emotes = {
         "_car_a_flirt_girl",
         "Lean Flirt",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["leanbar2"] = {
@@ -7016,7 +6791,7 @@ RP.Emotes = {
         "idle_c",
         "Lean Bar 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["leanbar3"] = {
@@ -7024,7 +6799,7 @@ RP.Emotes = {
         "clubvip_base_laz",
         "Lean Bar 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["leanbar4"] = {
@@ -7032,7 +6807,7 @@ RP.Emotes = {
         "ped_b_loop_a",
         "Lean Bar 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["leanhigh"] = {
@@ -7040,8 +6815,7 @@ RP.Emotes = {
         "idle_a_player_one",
         "Lean High",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanhigh2"] = {
@@ -7049,8 +6823,7 @@ RP.Emotes = {
         "idle_a_player_two",
         "Lean High 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanside"] = {
@@ -7058,8 +6831,7 @@ RP.Emotes = {
         "idle_a",
         "Leanside",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanside2"] = {
@@ -7067,8 +6839,7 @@ RP.Emotes = {
         "packer_idle_1_trevor",
         "Leanside 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanside3"] = {
@@ -7076,8 +6847,7 @@ RP.Emotes = {
         "waitloop_lamar",
         "Leanside 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanside4"] = {
@@ -7085,8 +6855,7 @@ RP.Emotes = {
         "waitloop_lamar",
         "Leanside 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["leanside5"] = {
@@ -7094,8 +6863,7 @@ RP.Emotes = {
         "josh_2_intp1_base",
         "Leanside 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["leanplan"] = {
@@ -7103,7 +6871,7 @@ RP.Emotes = {
         "idle_01_amy_skater_01",
         "Lean On Table",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 200,
             ExitEmote = "offtable",
         }
@@ -7113,7 +6881,7 @@ RP.Emotes = {
         "gesture_me_hard",
         "Me",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -7122,7 +6890,7 @@ RP.Emotes = {
         "fixing_a_ped",
         "Mechanic",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["mechanic2"] = {
@@ -7130,7 +6898,7 @@ RP.Emotes = {
         "fixing_a_player",
         "Mechanic 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["mechanic3"] = {
@@ -7138,7 +6906,7 @@ RP.Emotes = {
         "base",
         "Mechanic 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7147,7 +6915,7 @@ RP.Emotes = {
         "machinic_loop_mechandplayer",
         "Mechanic 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["mechanic5"] = {
@@ -7155,7 +6923,7 @@ RP.Emotes = {
         "idle_b",
         "Mechanic 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["medic2"] = {
@@ -7163,7 +6931,7 @@ RP.Emotes = {
         "base",
         "Medic 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["meditate"] = {
@@ -7171,7 +6939,7 @@ RP.Emotes = {
         "meditiate_idle",
         "Meditate",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 300,
             ExitEmote = "meditateup",
         }
@@ -7181,7 +6949,7 @@ RP.Emotes = {
         "ep_3_rcm_marnie_meditating",
         "Meditate 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 300,
             ExitEmote = "meditateup",
         }
@@ -7191,7 +6959,7 @@ RP.Emotes = {
         "base_loop",
         "Meditate 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 300,
             ExitEmote = "meditateup",
         }
@@ -7202,8 +6970,7 @@ RP.Emotes = {
         "Metal",
         AnimationOptions = {
             -- CHANGE ME
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["no"] = {
@@ -7211,7 +6978,7 @@ RP.Emotes = {
         "fail",
         "No",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -7220,7 +6987,7 @@ RP.Emotes = {
         "mp_player_int_nod_no",
         "No 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -7229,8 +6996,7 @@ RP.Emotes = {
         "nose_pick",
         "Nose Pick",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["noway"] = {
@@ -7239,7 +7005,7 @@ RP.Emotes = {
         "No Way",
         AnimationOptions = {
             EmoteDuration = 1500,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["ok"] = {
@@ -7247,8 +7013,7 @@ RP.Emotes = {
         "idle_a",
         "OK",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dock"] = {
@@ -7256,8 +7021,7 @@ RP.Emotes = {
         "idle_a",
         "Dock",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["outofbreath"] = {
@@ -7275,7 +7039,7 @@ RP.Emotes = {
         "pushcar_offcliff_f",
         "Push",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["push2"] = {
@@ -7283,7 +7047,7 @@ RP.Emotes = {
         "pushcar_offcliff_m",
         "Push 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["point"] = {
@@ -7291,8 +7055,7 @@ RP.Emotes = {
         "gesture_point",
         "Point",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pushup"] = {
@@ -7300,7 +7063,7 @@ RP.Emotes = {
         "idle_d",
         "Pushup",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["countdown"] = {
@@ -7308,8 +7071,7 @@ RP.Emotes = {
         "grid_girl_race_start",
         "Countdown",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pointright"] = {
@@ -7317,8 +7079,7 @@ RP.Emotes = {
         "indicate_right",
         "Point Right",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["salute"] = {
@@ -7326,8 +7087,7 @@ RP.Emotes = {
         "idle_a",
         "Salute",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["salute2"] = {
@@ -7335,8 +7095,7 @@ RP.Emotes = {
         "idle_a",
         "Salute 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["salute3"] = {
@@ -7344,8 +7103,7 @@ RP.Emotes = {
         "idle_a",
         "Salute 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["scared"] = {
@@ -7353,8 +7111,7 @@ RP.Emotes = {
         "f_distressed_loop",
         "Scared",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["scared2"] = {
@@ -7362,8 +7119,7 @@ RP.Emotes = {
         "knees_loop_girl",
         "Scared 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["scared3"] = {
@@ -7371,8 +7127,7 @@ RP.Emotes = {
         "csb_labrat_dual-5",
         "Scared 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["screwyou"] = {
@@ -7380,8 +7135,7 @@ RP.Emotes = {
         "screw_you",
         "Screw You",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shakeoff"] = {
@@ -7389,7 +7143,7 @@ RP.Emotes = {
         "shakeoff_1",
         "Shake Off",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3500
         }
     },
@@ -7398,7 +7152,7 @@ RP.Emotes = {
         "idle_a",
         "Shot",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7407,7 +7161,7 @@ RP.Emotes = {
         "base",
         "Sleep",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
@@ -7419,7 +7173,7 @@ RP.Emotes = {
         "idle_b",
         "Bum Sleep",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
@@ -7431,7 +7185,7 @@ RP.Emotes = {
         "gesture_shrug_hard",
         "Shrug",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -7440,7 +7194,7 @@ RP.Emotes = {
         "gesture_shrug_hard",
         "Shrug 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -7449,7 +7203,7 @@ RP.Emotes = {
         "sit_phone_phoneputdown_idle_nowork",
         "Sit",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7458,7 +7212,7 @@ RP.Emotes = {
         "barry_3_sit_loop",
         "Sit 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7467,7 +7221,7 @@ RP.Emotes = {
         "world_human_picnic_male_lo_res_base",
         "Sit 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7476,7 +7230,7 @@ RP.Emotes = {
         "world_human_picnic_female_lo_res_base",
         "Sit 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7485,7 +7239,7 @@ RP.Emotes = {
         "owner_idle",
         "Sit 5",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7494,7 +7248,7 @@ RP.Emotes = {
         "idle_a_jimmy",
         "Sit 6",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7503,7 +7257,7 @@ RP.Emotes = {
         "lowalone_base_laz",
         "Sit 7",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             ExitEmote = "getup",
         }
@@ -7513,7 +7267,7 @@ RP.Emotes = {
         "mics3_15_base_jimmy",
         "Sit 8",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7522,7 +7276,7 @@ RP.Emotes = {
         "idle_a",
         "Sit 9",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7531,7 +7285,7 @@ RP.Emotes = {
         "hiding_sit",
         "Sit 10",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7540,7 +7294,7 @@ RP.Emotes = {
         "single80_clip",
         "Sit Middle Finger",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7549,7 +7303,6 @@ RP.Emotes = {
         "you're_back",
         "Welcome Back",
         AnimationOptions = {
-            EmoteLoop = false,
         }
     },
     ["wallpose"] = { -- Credit to LadyyShamrockk for this custom emote
@@ -7557,7 +7310,7 @@ RP.Emotes = {
         "pose",
         "Wall Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["wallpose2"] = { -- Credit to LadyyShamrockk for this custom emote
@@ -7565,7 +7318,7 @@ RP.Emotes = {
         "pose",
         "Wall Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["wallpose3"] = { -- Credit to LadyyShamrockk for this custom emote
@@ -7573,7 +7326,7 @@ RP.Emotes = {
         "pose",
         "Wall Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["wallpose4"] = { -- Credit to LadyyShamrockk for this custom emote
@@ -7581,7 +7334,7 @@ RP.Emotes = {
         "pose",
         "Wall Pose 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["wallpose5"] = { -- Credit to LadyyShamrockk for this custom emote
@@ -7589,7 +7342,7 @@ RP.Emotes = {
         "pose",
         "Wall Pose 5",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["elbow"] = {
@@ -7597,7 +7350,7 @@ RP.Emotes = {
         "sit_low_lowdoor",
         "Window Elbow",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["elbow2"] = { -- Custom Emote By Chocoholic Animations
@@ -7606,7 +7359,7 @@ RP.Emotes = {
         "Window Elbow 2",
         AnimationOptions = {
             onlyInVehicle = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["sitlean"] = {
@@ -7614,7 +7367,7 @@ RP.Emotes = {
         "ig_14_base_tracy",
         "Sit Lean",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7623,7 +7376,7 @@ RP.Emotes = {
         "male_pos_a_p2_base",
         "Sit Lean 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7632,7 +7385,7 @@ RP.Emotes = {
         "base_pose_01",
         "Sit Lean 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7641,7 +7394,7 @@ RP.Emotes = {
         "sit_phone_phoneputdown_sleeping-noworkfemale",
         "Sit Sad",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7650,7 +7403,7 @@ RP.Emotes = {
         "f_sit_01_clip",
         "Sit Sad 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7659,7 +7412,7 @@ RP.Emotes = {
         "hit_loop_ped_b",
         "Sit Scared",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             NotInVehicle = true
@@ -7670,7 +7423,7 @@ RP.Emotes = {
         "flinch_loop",
         "Sit Scared 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             NotInVehicle = true
@@ -7681,7 +7434,7 @@ RP.Emotes = {
         "flinch_loop",
         "Sit Scared 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             NotInVehicle = true
@@ -7692,7 +7445,7 @@ RP.Emotes = {
         "base",
         "Sit Drunk",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -7701,7 +7454,7 @@ RP.Emotes = {
         "base",
         "Sit Chair",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7710,7 +7463,7 @@ RP.Emotes = {
         "ig_5_p3_base",
         "Sit Chair 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7719,7 +7472,7 @@ RP.Emotes = {
         "base_amanda",
         "Sit Chair 3 (Female)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7728,7 +7481,7 @@ RP.Emotes = {
         "ig_2_alt1_base",
         "Sit Chair 4 - Side",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7737,7 +7490,7 @@ RP.Emotes = {
         "mics3_15_base_tracy",
         "Sit Chair Legs Crossed",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7746,7 +7499,7 @@ RP.Emotes = {
         "base",
         "Sit Chair Lean Back",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7755,7 +7508,7 @@ RP.Emotes = {
         "sit_base_jimmy",
         "Sit Chair Attentive",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7764,7 +7517,7 @@ RP.Emotes = {
         "lonely_ballas",
         "Sit Chair Lonely",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7773,7 +7526,7 @@ RP.Emotes = {
         "base_pose_01",
         "Sit toilet",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7782,7 +7535,7 @@ RP.Emotes = {
         "idle",
         "Sit Toilet 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7791,8 +7544,7 @@ RP.Emotes = {
         "kylie_clip",
         "Sit Cute",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
         }
     },
@@ -7801,7 +7553,7 @@ RP.Emotes = {
         "idle_a",
         "Sit Up",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["smokengun"] = {
@@ -7819,7 +7571,7 @@ RP.Emotes = {
               -43.1362,
               -27.9428
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_mp_cig",
@@ -7864,8 +7616,7 @@ RP.Emotes = {
               -78.3079,
                 7.9470
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -7888,7 +7639,7 @@ RP.Emotes = {
         "angry_clap_a_player_a",
         "Clap Angry",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["slowclap3"] = {
@@ -7896,8 +7647,7 @@ RP.Emotes = {
         "idle_a",
         "Slow Clap 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["clap"] = {
@@ -7905,8 +7655,7 @@ RP.Emotes = {
         "base",
         "Clap",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["slowclap"] = {
@@ -7914,8 +7663,7 @@ RP.Emotes = {
         "slow_clap",
         "Slow Clap",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["slowclap2"] = {
@@ -7923,8 +7671,7 @@ RP.Emotes = {
         "slow_clap",
         "Slow Clap 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["smell"] = {
@@ -7932,8 +7679,7 @@ RP.Emotes = {
         "fidget_sniff_fingers",
         "Smell",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["solo_stickup"] = {
@@ -7941,8 +7687,7 @@ RP.Emotes = {
         "biker_02_stickup_loop",
         "Stick Up",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stumble"] = {
@@ -7950,7 +7695,7 @@ RP.Emotes = {
         "stumble",
         "Stumble",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["stunned"] = {
@@ -7958,7 +7703,7 @@ RP.Emotes = {
         "damage",
         "Stunned",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["sunbathe"] = {
@@ -7966,7 +7711,7 @@ RP.Emotes = {
         "base",
         "Sunbathe - Hand On Head",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -7977,7 +7722,7 @@ RP.Emotes = {
         "base",
         "Sunbathe 2 - Hand Over Face",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -7988,7 +7733,7 @@ RP.Emotes = {
         "base",
         "Sunbathe 3 - Lay On Stomach",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -7999,8 +7744,7 @@ RP.Emotes = {
         "a2_pose",
         "T Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tpose2"] = {
@@ -8008,7 +7752,7 @@ RP.Emotes = {
         "bind_pose_180",
         "T Pose 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["think5"] = {
@@ -8016,7 +7760,7 @@ RP.Emotes = {
         "b_think",
         "Think 5",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -8025,8 +7769,7 @@ RP.Emotes = {
         "rehearsal_base_idle_director",
         "Think",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["think3"] = {
@@ -8034,8 +7777,7 @@ RP.Emotes = {
         "base",
         "Think 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["think2"] = {
@@ -8043,8 +7785,7 @@ RP.Emotes = {
         "jh_int_outro_loop_a",
         "Think 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["thumbsup3"] = {
@@ -8052,7 +7793,7 @@ RP.Emotes = {
         "enter",
         "Thumbs Up 3",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -8061,8 +7802,7 @@ RP.Emotes = {
         "idle_a",
         "Thumbs Up 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["thumbsup"] = {
@@ -8070,8 +7810,7 @@ RP.Emotes = {
         "idle_a",
         "Thumbs Up",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["type"] = {
@@ -8079,8 +7818,7 @@ RP.Emotes = {
         "cop_b_idle",
         "Type",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["type2"] = {
@@ -8088,8 +7826,7 @@ RP.Emotes = {
         "loop",
         "Type 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["type3"] = {
@@ -8097,8 +7834,7 @@ RP.Emotes = {
         "hack_loop",
         "Type 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["type4"] = {
@@ -8106,7 +7842,7 @@ RP.Emotes = {
         "loop",
         "Type 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["type5"] = {
@@ -8114,7 +7850,7 @@ RP.Emotes = {
         "loop",
         "Type 5 - Stare",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["warmth"] = {
@@ -8122,8 +7858,7 @@ RP.Emotes = {
         "idle_a",
         "Warmth",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave4"] = {
@@ -8131,7 +7866,7 @@ RP.Emotes = {
         "001445_01_gangintimidation_1_female_idle_b",
         "Wave 4",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -8140,8 +7875,7 @@ RP.Emotes = {
         "wave",
         "Wave 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave3"] = {
@@ -8149,8 +7883,7 @@ RP.Emotes = {
         "over_here_idle_a",
         "Wave 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave"] = {
@@ -8158,8 +7891,7 @@ RP.Emotes = {
         "wave_a",
         "Wave",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave5"] = {
@@ -8167,8 +7899,7 @@ RP.Emotes = {
         "wave_b",
         "Wave 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave6"] = {
@@ -8176,8 +7907,7 @@ RP.Emotes = {
         "wave_c",
         "Wave 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave7"] = {
@@ -8185,8 +7915,7 @@ RP.Emotes = {
         "wave_d",
         "Wave 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave8"] = {
@@ -8194,8 +7923,7 @@ RP.Emotes = {
         "wave_e",
         "Wave 8",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wave9"] = {
@@ -8203,8 +7931,7 @@ RP.Emotes = {
         "gesture_hello",
         "Wave 9",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["whistle"] = {
@@ -8212,7 +7939,7 @@ RP.Emotes = {
         "hail_taxi",
         "Whistle",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1300
         }
     },
@@ -8221,7 +7948,7 @@ RP.Emotes = {
         "hailing_whistle_waive_a",
         "Whistle 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -8230,8 +7957,7 @@ RP.Emotes = {
         "idle_a",
         "Yeah",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["yeah2"] = {
@@ -8239,8 +7965,6 @@ RP.Emotes = {
         "csb_jenettee_dual-37",
         "Yeah Yeah",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = false
         }
     },
     ["yoga2"] = {
@@ -8248,8 +7972,7 @@ RP.Emotes = {
         "ig_4_idle",
         "Yoga 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["lift"] = {
@@ -8257,8 +7980,7 @@ RP.Emotes = {
         "idle_f",
         "Lift",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lol"] = {
@@ -8266,7 +7988,7 @@ RP.Emotes = {
         "laugh_a_player_b",
         "LOL",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lol2"] = {
@@ -8274,7 +7996,7 @@ RP.Emotes = {
         "giggle_a_player_b",
         "LOL 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["lostconfused"] = {
@@ -8282,7 +8004,6 @@ RP.Emotes = {
         "i_lost_it",
         "Lost & Confused",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["statue2"] = {
@@ -8290,8 +8011,7 @@ RP.Emotes = {
         "cs_lamardavis_dual-1",
         "Statue 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["statue3"] = {
@@ -8299,7 +8019,7 @@ RP.Emotes = {
         "csb_englishdave_dual-0",
         "Statue 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["gangsign"] = {
@@ -8307,8 +8027,7 @@ RP.Emotes = {
         "mp_player_int_gang_sign_a",
         "Gang Sign",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gangsign2"] = {
@@ -8316,8 +8035,7 @@ RP.Emotes = {
         "mp_player_int_gang_sign_b",
         "Gang Sign 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gangsign3"] = {
@@ -8325,8 +8043,7 @@ RP.Emotes = {
         "idle_a",
         "Gang Sign 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gangsign4"] = {
@@ -8334,8 +8051,7 @@ RP.Emotes = {
         "idle_a",
         "Gang Sign 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["passout"] = {
@@ -8343,7 +8059,7 @@ RP.Emotes = {
         "drunk_loop",
         "Passout",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8354,7 +8070,7 @@ RP.Emotes = {
         "corpse_search_exit_ped",
         "Passout 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8365,7 +8081,7 @@ RP.Emotes = {
         "body_search",
         "Passout 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8376,7 +8092,7 @@ RP.Emotes = {
         "cpr_pumpchest_idle",
         "Passout 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8387,7 +8103,7 @@ RP.Emotes = {
         "flee_backward_loop_shopkeeper",
         "Passout 5",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8398,7 +8114,7 @@ RP.Emotes = {
         "fix_bil_ig2_chopper_crawl_loop_ped",
         "Passout 6",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8409,7 +8125,7 @@ RP.Emotes = {
         "fix_bil_ig2_chopper_crawl_dead_loop_ped",
         "Passout 7",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8420,7 +8136,7 @@ RP.Emotes = {
         "fix_bil_ig2_chopper_crawl_dead_loop_ped",
         "Passout 8",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 900,
             NotInVehicle = true,
             ExitEmote = "getup",
@@ -8431,7 +8147,7 @@ RP.Emotes = {
         "petting_franklin",
         "Petting",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["crawl"] = {
@@ -8439,7 +8155,7 @@ RP.Emotes = {
         "front_loop",
         "Crawl",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "meditateup",
         }
@@ -8479,7 +8195,7 @@ RP.Emotes = {
         "flip_off_a_1st",
         "Flip Off",
         AnimationOptions = {
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["flipoff2"] = {
@@ -8487,7 +8203,7 @@ RP.Emotes = {
         "flip_off_c_1st",
         "Flip Off 2",
         AnimationOptions = {
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["bow"] = {
@@ -8495,8 +8211,7 @@ RP.Emotes = {
         "regal_c_1st",
         "Bow",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bow2"] = {
@@ -8504,8 +8219,7 @@ RP.Emotes = {
         "regal_a_1st",
         "Bow 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["keyfob"] = {
@@ -8513,8 +8227,7 @@ RP.Emotes = {
         "fob_click",
         "Key Fob",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1000
         }
     },
@@ -8523,8 +8236,7 @@ RP.Emotes = {
         "idle",
         "Holster",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["holster2"] = { -- Custom Emote Provided To RpEmotes By Mads
@@ -8532,8 +8244,7 @@ RP.Emotes = {
         "idle",
         "Holster 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["holster3"] = {
@@ -8541,8 +8252,7 @@ RP.Emotes = {
         "holster_walk",
         "Holster 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["holster4"] = {
@@ -8550,8 +8260,7 @@ RP.Emotes = {
         "holster_stop",
         "Holster 4 - Stop",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["holster5"] = {
@@ -8559,8 +8268,7 @@ RP.Emotes = {
         "holster_hold",
         "Holster 5 - Stop 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["solo_slap"] = {
@@ -8568,8 +8276,7 @@ RP.Emotes = {
         "plyr_takedown_front_slap",
         "Slap",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2000
         }
     },
@@ -8583,8 +8290,7 @@ RP.Emotes = {
         "idle_a",
         "Fish Dance",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace"] = {
@@ -8592,8 +8298,7 @@ RP.Emotes = {
         "mp_player_int_peace_sign",
         "Peace",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace2"] = {
@@ -8601,8 +8306,7 @@ RP.Emotes = {
         "idle_a",
         "Peace 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace3"] = {
@@ -8610,8 +8314,7 @@ RP.Emotes = {
         "idle_a_fp",
         "Peace 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace4"] = {
@@ -8619,8 +8322,7 @@ RP.Emotes = {
         "idle_a",
         "Peace 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace5"] = {
@@ -8628,8 +8330,7 @@ RP.Emotes = {
         "idle_a_fp",
         "Peace 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace6"] = {
@@ -8637,8 +8338,7 @@ RP.Emotes = {
         "idle_a",
         "Peace 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peace7"] = {
@@ -8646,8 +8346,7 @@ RP.Emotes = {
         "idle_a_fp",
         "Peace 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peacef"] = {
@@ -8655,8 +8354,7 @@ RP.Emotes = {
         "peace",
         "Peace Female",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cpr"] = {
@@ -8664,7 +8362,7 @@ RP.Emotes = {
         "cpr_pumpchest",
         "CPR",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["cpr2"] = {
@@ -8672,8 +8370,7 @@ RP.Emotes = {
         "cpr_pumpchest",
         "CPR 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ledge"] = {
@@ -8681,7 +8378,7 @@ RP.Emotes = {
         "ledge_loop",
         "Ledge",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["airplane"] = {
@@ -8689,8 +8386,7 @@ RP.Emotes = {
         "ledge_loop",
         "Air Plane",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["peek"] = {
@@ -8698,7 +8394,7 @@ RP.Emotes = {
         "left_peek_a",
         "Peek",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["cough"] = {
@@ -8706,8 +8402,7 @@ RP.Emotes = {
         "idle_cough",
         "Cough",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stretch"] = {
@@ -8715,7 +8410,7 @@ RP.Emotes = {
         "idle_e",
         "Stretch",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["stretch2"] = {
@@ -8723,7 +8418,7 @@ RP.Emotes = {
         "idle_f",
         "Stretch 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["stretch3"] = {
@@ -8731,7 +8426,7 @@ RP.Emotes = {
         "idle_d",
         "Stretch 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["stretch4"] = {
@@ -8739,7 +8434,7 @@ RP.Emotes = {
         "idle_e",
         "Stretch 4",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["celebrate"] = {
@@ -8747,7 +8442,7 @@ RP.Emotes = {
         "celebrate",
         "Celebrate",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["punching"] = {
@@ -8755,8 +8450,7 @@ RP.Emotes = {
         "loop_punching",
         "Punching",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["punching2"] = {
@@ -8764,8 +8458,6 @@ RP.Emotes = {
         "standing_punch_v1_golfer",
         "Punching 2",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = false
         }
     },
     ["superhero"] = {
@@ -8773,7 +8465,7 @@ RP.Emotes = {
         "base",
         "Superhero",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["superhero2"] = {
@@ -8781,8 +8473,7 @@ RP.Emotes = {
         "base",
         "Superhero 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mindcontrol"] = {
@@ -8790,7 +8481,7 @@ RP.Emotes = {
         "mind_control_b_loop",
         "Mind Control",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["mindcontrol2"] = {
@@ -8798,7 +8489,7 @@ RP.Emotes = {
         "bar_1_attack_idle_aln",
         "Mind Control 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["clown"] = {
@@ -8806,7 +8497,7 @@ RP.Emotes = {
         "clown_idle_0",
         "Clown",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["clown2"] = {
@@ -8814,7 +8505,7 @@ RP.Emotes = {
         "clown_idle_1",
         "Clown 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["clown3"] = {
@@ -8822,7 +8513,7 @@ RP.Emotes = {
         "clown_idle_2",
         "Clown 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["clown4"] = {
@@ -8830,8 +8521,7 @@ RP.Emotes = {
         "clown_idle_3",
         "Clown 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["clown5"] = {
@@ -8839,7 +8529,7 @@ RP.Emotes = {
         "clown_idle_6",
         "Clown 5",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["tryclothes"] = {
@@ -8847,7 +8537,7 @@ RP.Emotes = {
         "try_trousers_neutral_a",
         "Try Clothes",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["tryclothes2"] = {
@@ -8855,7 +8545,7 @@ RP.Emotes = {
         "try_shirt_positive_a",
         "Try Clothes 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["tryclothes3"] = {
@@ -8863,7 +8553,7 @@ RP.Emotes = {
         "try_shoes_positive_a",
         "Try Clothes 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["tryclothes4"] = {
@@ -8871,7 +8561,6 @@ RP.Emotes = {
         "change_highroller",
         "Try Clothes 4",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["tryclothes5"] = {
@@ -8879,7 +8568,6 @@ RP.Emotes = {
         "change_highroller_male",
         "Try Clothes 5",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["nervous"] = {
@@ -8887,8 +8575,7 @@ RP.Emotes = {
         "idle_c",
         "Nervous",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["nervous2"] = {
@@ -8896,8 +8583,7 @@ RP.Emotes = {
         "nervous_idle",
         "Nervous 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["nervous3"] = {
@@ -8905,8 +8591,7 @@ RP.Emotes = {
         "nervous_loop",
         "Nervous 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["nervous4"] = {
@@ -8914,8 +8599,6 @@ RP.Emotes = {
         "cs_marnie_dual-9",
         "Nervous 4",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = false
         }
     },
     ["namaste"] = {
@@ -8923,8 +8606,7 @@ RP.Emotes = {
         "ig_4_base",
         "Namaste",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["threaten"] = {
@@ -8932,8 +8614,7 @@ RP.Emotes = {
         "b_atm_mugging",
         "Threaten",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["radio"] = {
@@ -8941,8 +8622,7 @@ RP.Emotes = {
         "generic_radio_chatter",
         "Radio",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pull"] = {
@@ -8950,8 +8630,7 @@ RP.Emotes = {
         "struggle_loop_b_thief",
         "Pull",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bird"] = {
@@ -8964,8 +8643,7 @@ RP.Emotes = {
         "wakeup",
         "Chicken",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bark"] = {
@@ -8983,7 +8661,7 @@ RP.Emotes = {
         "ex03_train_roof_idle",
         "Spider-Man",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             NotInVehicle = true
         }
     },
@@ -8992,7 +8670,7 @@ RP.Emotes = {
         "brotheradrianhasshown_2",
         "BOI",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3000
         }
     },
@@ -9001,7 +8679,7 @@ RP.Emotes = {
         "michael_tux_fidget",
         "Adjust",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -9010,8 +8688,7 @@ RP.Emotes = {
         "base",
         "Addict",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["handsup"] = {
@@ -9019,8 +8696,7 @@ RP.Emotes = {
         "handsup_base",
         "Hands Up",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["handsup2"] = {
@@ -9028,8 +8704,7 @@ RP.Emotes = {
         "idle_a_fp",
         "Hands Up 2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['handsup3'] = {
@@ -9037,8 +8712,7 @@ RP.Emotes = {
         'hands_up_idle_a_player_one',
         'Hands Up 3',
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['handsup4'] = {
@@ -9046,8 +8720,7 @@ RP.Emotes = {
         'leaning_idle_bounty',
         'Hands Up 4',
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['handsup5'] = {
@@ -9055,8 +8728,7 @@ RP.Emotes = {
         'standing_idle_bounty',
         'Hands Up 5',
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["valet"] = {
@@ -9064,8 +8736,7 @@ RP.Emotes = {
         "base_a_m_y_vinewood_01",
         "Valet",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["valet2"] = {
@@ -9073,8 +8744,7 @@ RP.Emotes = {
         "base_a_m_y_vinewood_01",
         "Valet 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["valet3"] = {
@@ -9082,8 +8752,7 @@ RP.Emotes = {
         "base_a_m_y_vinewood_01",
         "Valet 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tighten"] = {
@@ -9091,7 +8760,7 @@ RP.Emotes = {
         "idle_b",
         "Tighten (Yoga)",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -9100,8 +8769,7 @@ RP.Emotes = {
         "c2_pose",
         "F Sex Pose",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true
     },
@@ -9110,8 +8778,7 @@ RP.Emotes = {
         "c6_pose",
         "F Sex Pose 2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             NotInVehicle = true
         },
         AdultAnimation = true
@@ -9121,8 +8788,7 @@ RP.Emotes = {
         "female_c_idle_d",
         "F Sex Pose 3",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true
     },
@@ -9131,8 +8797,7 @@ RP.Emotes = {
         "shower_enter_into_idle",
         "Shower Enter Female",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerf2"] = {
@@ -9140,8 +8805,7 @@ RP.Emotes = {
         "shower_idle_a",
         "Shower Female",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerf3"] = {
@@ -9149,8 +8813,7 @@ RP.Emotes = {
         "shower_idle_b",
         "Shower Female 2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerm"] = {
@@ -9158,8 +8821,7 @@ RP.Emotes = {
         "male_shower_idle_a",
         "Shower Enter Male",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerm2"] = {
@@ -9167,8 +8829,7 @@ RP.Emotes = {
         "male_shower_idle_b",
         "Shower Male 2",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerm3"] = {
@@ -9176,8 +8837,7 @@ RP.Emotes = {
         "male_shower_idle_c",
         "Shower Male 3",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showerm4"] = {
@@ -9185,8 +8845,7 @@ RP.Emotes = {
         "male_shower_idle_d",
         "Shower Male 4",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["picklock"] = {
@@ -9194,8 +8853,7 @@ RP.Emotes = {
         "hassle_intro_loop_f",
         "Picklock",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cleanhands"] = {
@@ -9203,8 +8861,7 @@ RP.Emotes = {
         "urinal_sink_loop",
         "Clean Them Filthy Hands",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cleanface"] = {
@@ -9212,8 +8869,7 @@ RP.Emotes = {
         "loop_michael",
         "Clean Your Face",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["buzz"] = {
@@ -9221,8 +8877,6 @@ RP.Emotes = {
         "buzz_reg",
         "Buzz Door",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = false
         }
     },
     ["grieve"] = {
@@ -9230,8 +8884,7 @@ RP.Emotes = {
         "idle_ped05",
         "Grieve The Dead",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["respect"] = {
@@ -9239,8 +8892,7 @@ RP.Emotes = {
         "respect",
         "Respect Male",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = false
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["respectf"] = {
@@ -9248,8 +8900,7 @@ RP.Emotes = {
         "respect",
         "Respect Female",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = false
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bang"] = {
@@ -9257,7 +8908,6 @@ RP.Emotes = {
         "bang_bang",
         "Bang Bang",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 2500
         }
     },
@@ -9266,7 +8916,7 @@ RP.Emotes = {
         "idle_b",
         "Check Out · Female",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["checkcar2"] = {
@@ -9274,7 +8924,7 @@ RP.Emotes = {
         "idle_a",
         "Check Out 2 · Male",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["showboobs"] = {
@@ -9282,7 +8932,6 @@ RP.Emotes = {
         "stripper_b_backroom_idle_b",
         "Show Boobs",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 6000,
         },
         AdultAnimation = true
@@ -9292,7 +8941,6 @@ RP.Emotes = {
         "stripper_idle_05",
         "Show Boobs 2",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 6000,
         },
         AdultAnimation = true
@@ -9302,7 +8950,6 @@ RP.Emotes = {
         "idle_b",
         "Watch Stripper",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 6000,
         },
         AdultAnimation = true
@@ -9312,8 +8959,7 @@ RP.Emotes = {
         "base",
         "Heart Hands",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pockets"] = { -- Custom Emote By Dark Animations
@@ -9321,8 +8967,7 @@ RP.Emotes = {
         "hoodie_hands_clip",
         "Hands in pockets (Hoodie)",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["posecutef"] = { -- Custom Emote By Pupppy
@@ -9330,8 +8975,7 @@ RP.Emotes = {
         "freepose01",
         "Cute Pose Female",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["posecutef2"] = { -- Custom Emote By Pupppy
@@ -9339,8 +8983,7 @@ RP.Emotes = {
         "freepose03",
         "Cute Pose Female 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["posecutef3"] = { -- Custom Emote By Pupppy
@@ -9348,8 +8991,7 @@ RP.Emotes = {
         "freepose04",
         "Cute Pose Female 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["posecutef4"] = { -- Custom Emote By QueenSistersAnimations
@@ -9357,8 +8999,7 @@ RP.Emotes = {
         "kylie_clip",
         "Cute Pose Female 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["posecutem"] = { -- Custom Emote By Pupppy
@@ -9366,8 +9007,7 @@ RP.Emotes = {
         "freepose02",
         "Cute Pose Male",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["checkwatch"] = { -- Custom Emote By MissSnowie
@@ -9375,8 +9015,7 @@ RP.Emotes = {
         "base",
         "Check Watch",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pee"] = {
@@ -9384,7 +9023,7 @@ RP.Emotes = {
         "peeing_loop",
         "Pee (Male)",
         AnimationOptions = {
-            EmoteStuck = true,
+            onFootflag = AnimFlag.STUCK,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -9408,8 +9047,7 @@ RP.Emotes = {
         "piss_loop",
         "Pee 2 (Male)",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -9433,8 +9071,7 @@ RP.Emotes = {
         "piss_loop",
         "Pee 3 Static (Male)",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_peeing",
             PtfxNoProp = true,
@@ -9458,8 +9095,7 @@ RP.Emotes = {
         "skull_loving_bear",
         "Hump",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true
     },
@@ -9468,8 +9104,7 @@ RP.Emotes = {
         "idle_a",
         "Wank",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -9478,8 +9113,7 @@ RP.Emotes = {
         "idle_a",
         "Wank 2",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -9488,8 +9122,7 @@ RP.Emotes = {
         "mp_player_int_wank_02",
         "Wank 3",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -9498,8 +9131,7 @@ RP.Emotes = {
         "mp_player_int_wank_02_fp",
         "Wank 4",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -9508,8 +9140,6 @@ RP.Emotes = {
         "mp_player_int_wank",
         "Wank 5",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = false
         },
         AdultAnimation = true
     },
@@ -9518,7 +9148,7 @@ RP.Emotes = {
         "001916_01_fras_v2_9_plays_w_dog_idle",
         "Call Dog",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["calldogr"] = {
@@ -9526,7 +9156,6 @@ RP.Emotes = {
         "call_chop_r",
         "Call Dog - Right",
         AnimationOptions = {
-            EmoteLoop = false,
         }
     },
     ["calldogl"] = {
@@ -9534,7 +9163,6 @@ RP.Emotes = {
         "call_chop_l",
         "Call Dog - Left",
         AnimationOptions = {
-            EmoteLoop = false,
         }
     },
     ["block"] = {
@@ -9542,8 +9170,7 @@ RP.Emotes = {
         "idle",
         "Block Face",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["policecrowd"] = {
@@ -9551,7 +9178,7 @@ RP.Emotes = {
         "idle_a",
         "Police Crowd",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["policecrowd2"] = {
@@ -9559,7 +9186,7 @@ RP.Emotes = {
         "idle_d",
         "Police Crowd 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
 	["k9pose"] = {
@@ -9567,8 +9194,7 @@ RP.Emotes = {
         "hug_dog",
         "Hug Dog",
         AnimationOptions = {
-            EmoteLoop = true,
-			EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["snot"] = {
@@ -9576,7 +9202,7 @@ RP.Emotes = {
         "fidget_blow_snot",
         "Blow Snot",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4500
         }
     },
@@ -9585,7 +9211,6 @@ RP.Emotes = {
         "fidget_scratch_balls",
         "Scratch Balls",
         AnimationOptions = {
-            EmoteMoving = false,
             EmoteDuration = 4000
         },
         AdultAnimation = true
@@ -9596,7 +9221,6 @@ RP.Emotes = {
         "Car Taunt",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9606,7 +9230,6 @@ RP.Emotes = {
         "Car Taunt 2",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9616,7 +9239,6 @@ RP.Emotes = {
         "Car Taunt 3",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9626,7 +9248,6 @@ RP.Emotes = {
         "Car Taunt 4",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9636,7 +9257,6 @@ RP.Emotes = {
         "Car Taunt 5",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 3000
         }
     },
@@ -9646,7 +9266,6 @@ RP.Emotes = {
         "Car Taunt 6",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 3000
         }
     },
@@ -9656,7 +9275,6 @@ RP.Emotes = {
         "Car Taunt 7",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9666,7 +9284,6 @@ RP.Emotes = {
         "Car Taunt 8",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9676,7 +9293,6 @@ RP.Emotes = {
         "Car Taunt 9",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 3000
         }
     },
@@ -9686,7 +9302,6 @@ RP.Emotes = {
         "Car Taunt 10",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9696,7 +9311,6 @@ RP.Emotes = {
         "Car Taunt 11",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9706,7 +9320,6 @@ RP.Emotes = {
         "Car Taunt 12",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 2000
         }
     },
@@ -9716,7 +9329,6 @@ RP.Emotes = {
         "Car Taunt 13",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 5000
         }
     },
@@ -9726,7 +9338,6 @@ RP.Emotes = {
         "Car Taunt 14",
         AnimationOptions = {
             onlyInVehicle = true,
-			EmoteMoving = false,
             EmoteDuration = 5000
         }
     },
@@ -9735,8 +9346,7 @@ RP.Emotes = {
         "pose_sport_002",
         "Flex 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true -- Allows us to flex while performing another animation
+            onFootFlag = AnimFlag.MOVING, -- Allows us to flex while performing another animation
         }
     },
     ["gym"] = { -- Custom Female Emote By Souris
@@ -9744,7 +9354,7 @@ RP.Emotes = {
         "air_squat_clip",
         "Gym - Squats",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["gym2"] = { -- Custom Female Emote By Souris
@@ -9752,7 +9362,7 @@ RP.Emotes = {
         "byc_crunch_clip",
         "Gym - Crunches",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 400,
             ExitEmote = "getup",
         }
@@ -9762,7 +9372,7 @@ RP.Emotes = {
         "jump_exc_clip",
         "Gym - Jumping",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["gym4"] = { -- Custom Female Emote By Souris
@@ -9770,7 +9380,7 @@ RP.Emotes = {
         "jump_jack_clip",
         "Gym - Jumping Jacks",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["gym5"] = { -- Custom Female Emote By Souris
@@ -9778,7 +9388,7 @@ RP.Emotes = {
         "situp_clip",
         "Gym - Sit Up",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 550,
             ExitEmote = "getup",
         }
@@ -9788,7 +9398,7 @@ RP.Emotes = {
         "pose_sport_001",
         "Gym Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             NotInVehicle = true
         }
     },
@@ -9797,7 +9407,7 @@ RP.Emotes = {
         "pose_sport_005",
         "Gym Pose 2 - One Handed Push Up",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 550,
             ExitEmote = "standup",
             ExitEmoteType = "Exits",
@@ -9809,7 +9419,7 @@ RP.Emotes = {
         "fem_pose_sport_004",
         "Gym Pose 3 - Planking Pose",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 550,
             ExitEmote = "standup",
             ExitEmoteType = "Exits",
@@ -9821,7 +9431,7 @@ RP.Emotes = {
         "fem_pose_sport_005",
         "Gym Pose 4 - Sit Ups Pose",
          AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 510,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
@@ -9858,7 +9468,7 @@ RP.Emotes = {
         "mind_blown",
         "Mind Blown",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -9867,7 +9477,7 @@ RP.Emotes = {
         "mind_blown",
         "Mind Blown 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -9876,7 +9486,7 @@ RP.Emotes = {
         "shadow_boxing",
         "Boxing",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -9885,7 +9495,7 @@ RP.Emotes = {
         "shadow_boxing",
         "Boxing 2",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 4000
         }
     },
@@ -9894,7 +9504,7 @@ RP.Emotes = {
         "idle",
         "Boxing 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["capoeira"] = {
@@ -9902,7 +9512,7 @@ RP.Emotes = {
         "med_right",
         "Capoeira",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["capoeira2"] = {
@@ -9910,7 +9520,7 @@ RP.Emotes = {
         "high_right_down",
         "Capoeira 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["stink"] = {
@@ -9918,8 +9528,7 @@ RP.Emotes = {
         "stinker",
         "Stink",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["taichi"] = {
@@ -9927,8 +9536,7 @@ RP.Emotes = {
         "lean_forward_idle",
         "Tai chi",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["taichi2"] = {
@@ -9936,8 +9544,6 @@ RP.Emotes = {
         "tai_chi_trevor",
         "Tai chi - Awkward",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = false
         }
     },
     ["think4"] = {
@@ -9945,8 +9551,7 @@ RP.Emotes = {
         "idle_a",
         "Think 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["adjusttie"] = {
@@ -9954,7 +9559,7 @@ RP.Emotes = {
         "try_tie_positive_a",
         "Adjust Tie",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 5000
         }
     },
@@ -9963,8 +9568,7 @@ RP.Emotes = {
         "base",
         "Shaka 'Hang Loose'",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shaka2"] = {
@@ -9972,8 +9576,7 @@ RP.Emotes = {
         "base",
         "Shaka 'Hang Loose Casual'",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["relax"] = {
@@ -9981,7 +9584,7 @@ RP.Emotes = {
         "base",
         "Relax",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             NotInVehicle = true,
             StartDelay = 800,
             ExitEmote = "getup",
@@ -9992,7 +9595,7 @@ RP.Emotes = {
         "base",
         "Relax 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             NotInVehicle = true,
             StartDelay = 800,
             ExitEmote = "getup",
@@ -10003,8 +9606,7 @@ RP.Emotes = {
         "base",
         "UwU",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dab"] = {
@@ -10012,8 +9614,7 @@ RP.Emotes = {
         "stand_dab_clip",
         "Dab",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sexypose"] = { -- Custom Emote By Little Spoon
@@ -10021,8 +9622,7 @@ RP.Emotes = {
         "sexy003",
         "Sexy Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose2"] = { -- Custom Emote By Little Spoon
@@ -10030,8 +9630,7 @@ RP.Emotes = {
         "sexy004",
         "Sexy Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose3"] = { -- Custom Emote By Little Spoon
@@ -10039,8 +9638,7 @@ RP.Emotes = {
         "sexy005",
         "Sexy Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose4"] = { -- Custom Emote By Little Spoon
@@ -10048,8 +9646,7 @@ RP.Emotes = {
         "sexy006",
         "Sexy Pose 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose5"] = { -- Custom Emote By Little Spoon
@@ -10057,8 +9654,7 @@ RP.Emotes = {
         "sexy009",
         "Sexy Pose 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose6"] = { -- Custom Emote By Little Spoon
@@ -10066,8 +9662,7 @@ RP.Emotes = {
         "sexy012",
         "Sexy Pose 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sexypose7"] = { -- Custom Emote By Darks Animations
@@ -10075,8 +9670,7 @@ RP.Emotes = {
         "bad_girls_pose3_clip",
         "Sexy Pose 7",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["laydownsexy"] = { -- Custom emote by Struggleville
@@ -10084,7 +9678,7 @@ RP.Emotes = {
         "laying_sexy_clip",
         "Laying Down Sexy",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10094,8 +9688,7 @@ RP.Emotes = {
         "model_showoff_clip",
         "Model Pose Sexy",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["model2"] = { -- Custom Emote By QueenSistersAnimations
@@ -10103,8 +9696,7 @@ RP.Emotes = {
         "sitdown_clip",
         "Model Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["model3"] = { -- Custom emote by Struggleville
@@ -10112,8 +9704,7 @@ RP.Emotes = {
         "photo_cute_clip",
         "Model Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["layncry"] = {
@@ -10121,7 +9712,7 @@ RP.Emotes = {
         "lowsofa_dlg_fuckedup_laz",
         "Lay & Cry",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10131,7 +9722,7 @@ RP.Emotes = {
         "lowsofa_base_laz",
         "Lay & Cry 2",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10141,7 +9732,7 @@ RP.Emotes = {
         "lowsofa_dlg_notagain_laz",
         "Lay & Cry 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10151,7 +9742,7 @@ RP.Emotes = {
         "lowsofa_dlg_notagain_laz",
         "Lay & Cry 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10161,7 +9752,7 @@ RP.Emotes = {
         "lowsofa_dlg_shit2strong_laz",
         "Lay & Cry 5",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10171,7 +9762,7 @@ RP.Emotes = {
         "2int_loop_a_taocheng",
         "Lay & Cry 6",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10181,7 +9772,7 @@ RP.Emotes = {
         "base",
         "Lay & Cry 7",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10191,7 +9782,7 @@ RP.Emotes = {
         "stage_3_base_golfer",
         "Lay & Cry 8",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10201,8 +9792,7 @@ RP.Emotes = {
         "bz_army1",
         "Army 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["army1l"] = {
@@ -10210,8 +9800,7 @@ RP.Emotes = {
         "bz_army1_left",
         "Army 1 Left",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["army1p"] = {
@@ -10219,8 +9808,7 @@ RP.Emotes = {
         "bz_army1_right",
         "Army 1 Right",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["army2"] = {
@@ -10228,8 +9816,7 @@ RP.Emotes = {
         "bz_army2",
         "Army 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["army2l"] = {
@@ -10237,8 +9824,7 @@ RP.Emotes = {
         "bz_army2_left",
         "Army 2 Left",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["army2p"] = {
@@ -10246,8 +9832,7 @@ RP.Emotes = {
         "bz_army2_right",
         "Army 2 Right",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["airforce01"] = { -- MissSnowie
@@ -10255,8 +9840,7 @@ RP.Emotes = {
         "base",
         "Airforce - At Ease", -- MissSnowie
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["airforce02"] = { -- MissSnowie
@@ -10264,8 +9848,7 @@ RP.Emotes = {
         "base",
         "Airforce - Attention",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["airforce03"] = { -- MissSnowie
@@ -10273,8 +9856,7 @@ RP.Emotes = {
         "base",
         "Airforce - Parade Rest",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["airforce04"] = {
@@ -10282,8 +9864,7 @@ RP.Emotes = {
         "base",
         "Airforce - Salute",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["zombiewalk"] = { -- Custom Emote By BoringNeptune
@@ -10291,8 +9872,7 @@ RP.Emotes = {
         "zombi_walk_01",
         "Zombie Walk",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false -- true looks weird but the option is here
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["zombiewalk2"] = { -- Custom Emote By BoringNeptune
@@ -10300,7 +9880,7 @@ RP.Emotes = {
         "zombi_walk_02",
         "Zombie Walk 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["zombiewalk3"] = {
@@ -10308,7 +9888,7 @@ RP.Emotes = {
         "walk_up",
         "Zombie Walk 3",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["zombiewalk4"] = {
@@ -10316,7 +9896,7 @@ RP.Emotes = {
         "run_turn_r3",
         "Zombie Run - Circle",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["zombieagony"] = { -- Custom Emote By BoringNeptune
@@ -10324,7 +9904,7 @@ RP.Emotes = {
         "agony",
         "Zombie Agony",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["zombiescream"] = { -- Custom Emote By BoringNeptune
@@ -10332,7 +9912,7 @@ RP.Emotes = {
         "scream",
         "Zombie Scream",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["zombiecrawl"] = { -- Custom Emote By BoringNeptune
@@ -10340,7 +9920,7 @@ RP.Emotes = {
         "crawl_01",
         "Zombie Crawl",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "meditateup",
         }
@@ -10350,7 +9930,6 @@ RP.Emotes = {
         "short_-180_punch",
         "Zombie Swipe",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["zombieswipe2"] = {
@@ -10358,7 +9937,6 @@ RP.Emotes = {
         "heavy_punch_b_var_2",
         "Zombie Swipe 2",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["zombieswipe3"] = {
@@ -10366,7 +9944,6 @@ RP.Emotes = {
         "short_90_punch",
         "Zombie Swipe 3",
         AnimationOptions = {
-            EmoteLoop = false
         }
     },
     ["laysexy"] = { -- Custom Emote By Amnilka
@@ -10374,7 +9951,7 @@ RP.Emotes = {
         "amnilka_femalehome_photopose_004",
         "Lay Sexy",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             StartDelay = 700,
             ExitEmote = "getup",
         }
@@ -10384,7 +9961,7 @@ RP.Emotes = {
         "rifle_photo_clip",
         "Rifle Pose",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["vest"] = {
@@ -10392,8 +9969,7 @@ RP.Emotes = {
         "holding_vest_clip",
         "Hold Vest",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vest2"] = {
@@ -10401,8 +9977,7 @@ RP.Emotes = {
         "holding_side_vest_clip",
         "Hold Vest 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vest3"] = {
@@ -10410,8 +9985,7 @@ RP.Emotes = {
         "holding_siege_vest_side_clip",
         "Hold Vest 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vest4"] = {
@@ -10419,8 +9993,7 @@ RP.Emotes = {
         "holding_vest_2_clip",
         "Hold Vest 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vest5"] = {
@@ -10428,8 +10001,7 @@ RP.Emotes = {
         "holding_vest_siege_clip",
         "Hold Vest 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vest6"] = {
@@ -10437,8 +10009,7 @@ RP.Emotes = {
         "holding_vest_siege_2_clip",
         "Hold Vest 6",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["kick"] = {
@@ -10446,7 +10017,7 @@ RP.Emotes = {
         "guard_beatup_kickidle_guard1",
         "Kick",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kick2"] = {
@@ -10454,7 +10025,7 @@ RP.Emotes = {
         "guard_beatup_kickidle_guard2",
         "Kick 2",
         AnimationOptions = {
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["kick3"] = {
@@ -10470,8 +10041,7 @@ RP.Emotes = {
         "male_e_base",
         "Cross hands",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["aslyes"] = {
@@ -10479,7 +10049,7 @@ RP.Emotes = {
         "ebrwny_yes",
         "ASL Yes 🇺🇸",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1030
         }
     },
@@ -10488,7 +10058,7 @@ RP.Emotes = {
         "ebrwny_no",
         "ASL No 🇺🇸",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2080
         }
     },
@@ -10497,7 +10067,7 @@ RP.Emotes = {
         "ebrwny_imgood",
         "ASL I Am Good 🇺🇸",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 3940
         }
     },
@@ -10506,7 +10076,7 @@ RP.Emotes = {
         "ebrwny_seeya",
         "ASL See Ya 🇺🇸",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1200
         }
     },
@@ -10515,7 +10085,7 @@ RP.Emotes = {
         "ebrwny_what",
         "ASL What 🇺🇸",
         AnimationOptions = {
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 1480
         }
     },
@@ -10524,8 +10094,7 @@ RP.Emotes = {
         "pistol_b_b_clip",
         "Hide a gun",
         AnimationOptions = {
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["femaleposea"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10533,8 +10102,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose A",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleadorable1"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10542,8 +10110,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Adorable 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleadorable2"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10551,8 +10118,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Adorable 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposeb"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10560,8 +10126,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose B",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposec"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10569,8 +10134,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose C",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposed"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10578,8 +10142,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose D",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposee"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10587,8 +10150,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose E",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposef"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10596,8 +10158,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose F",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposeg"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10605,8 +10166,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose G",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposeh"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10614,8 +10174,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose H",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposei"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10623,8 +10182,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose I",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposej"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10632,8 +10190,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose J",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposek"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10641,8 +10198,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose K",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposel"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10650,8 +10206,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose L",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposem"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10659,8 +10214,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose M",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposen"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10668,8 +10222,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose N",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposeo"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10677,8 +10230,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose O",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposep"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10686,8 +10238,7 @@ RP.Emotes = {
         "mrwitt",
         "Female Pose P",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposer"] = { -- Custom Emote By DRX Animations
@@ -10695,8 +10246,7 @@ RP.Emotes = {
         "xrd",
         "Female Pose R",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposes"] = { -- Custom Emote By DRX Animations
@@ -10704,8 +10254,7 @@ RP.Emotes = {
         "xrd",
         "Female Pose S",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposet"] = { -- Custom Emote By DRX Animations
@@ -10713,8 +10262,7 @@ RP.Emotes = {
         "xrd",
         "Female Pose T",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposeu"] = { -- Custom Emote By DRX Animations
@@ -10722,8 +10270,7 @@ RP.Emotes = {
         "drx",
         "Female Pose U",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -10732,8 +10279,7 @@ RP.Emotes = {
         "drx",
         "Female Pose V",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposew"] = { -- Custom Emote By DRX Animations
@@ -10741,8 +10287,7 @@ RP.Emotes = {
         "drx",
         "Female Pose W",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposex"] = { -- Custom Emote By DRX Animations
@@ -10750,8 +10295,7 @@ RP.Emotes = {
     "xrd",
     "Female Pose X",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposey"] = { -- Custom Emote By DRX Animations
@@ -10759,8 +10303,7 @@ RP.Emotes = {
     "xrd",
     "Female Pose Y",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["femaleposez"] = { -- Custom Emote By DRX Animations
@@ -10768,8 +10311,7 @@ RP.Emotes = {
         "xrd",
         "Female Pose Z",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
 	["maleposea"] = { -- Custom Emote By DRX Animations
@@ -10777,8 +10319,7 @@ RP.Emotes = {
         "drx",
         "Male Pose A",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
        }
     },
     ["maleposeb"] = { -- Custom Emote By DRX Animations
@@ -10786,8 +10327,7 @@ RP.Emotes = {
         "drx",
         "Male Pose B",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposec"] = { -- Custom Emote By DRX Animations
@@ -10795,8 +10335,7 @@ RP.Emotes = {
         "drx",
         "Male Pose C",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposed"] = { -- Custom Emote By DRX Animations
@@ -10804,8 +10343,7 @@ RP.Emotes = {
         "drx",
         "Male Pose D",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposee"] = { -- Custom Emote By DRX Animations
@@ -10813,8 +10351,7 @@ RP.Emotes = {
         "drx",
         "Male Pose E",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposef"] = { -- Custom Emote By DRX Animations
@@ -10822,8 +10359,7 @@ RP.Emotes = {
         "drx",
         "Male Pose F",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposee1"] = { -- Custom Emote By DRX Animations
@@ -10831,8 +10367,7 @@ RP.Emotes = {
         "xrd",
         "Male Pose E1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposef1"] = { -- Custom Emote By DRX Animations
@@ -10840,8 +10375,7 @@ RP.Emotes = {
         "xrd",
         "Male Pose F1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposeg"] = { -- Custom Emote By DRX Animations
@@ -10849,8 +10383,7 @@ RP.Emotes = {
         "pose_male",
         "Male Pose G",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposeh"] = { -- Custom Emote By MrWitt
@@ -10858,8 +10391,7 @@ RP.Emotes = {
         "mrwitt",
         "Male Pose H",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposei"] = { -- Custom Emote By MrWitt
@@ -10867,8 +10399,7 @@ RP.Emotes = {
         "mrwitt",
         "Male Pose I",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleposetie"] = { -- Custom Emotes By MrWhitt Provided To RPEmotes 01/08/2023
@@ -10876,8 +10407,7 @@ RP.Emotes = {
         "mrwitt",
         "Male Pose Tie",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malecrossarms"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10885,8 +10415,7 @@ RP.Emotes = {
         "cross_arms_clip",
         "Male Cross Arms",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malemiddlefinger"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10894,8 +10423,7 @@ RP.Emotes = {
         "stand_middlefinger_clip",
         "Male Middle Finger",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malefistface"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10903,8 +10431,7 @@ RP.Emotes = {
         "fist_face_clip",
         "Male Fist Face",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malepose4"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10912,8 +10439,7 @@ RP.Emotes = {
         "fuckm_clip",
         "Male Pose 4",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malegunpose1"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10921,8 +10447,7 @@ RP.Emotes = {
         "gun_ink_clip",
         "Male Gun Pose 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malepose5"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10930,8 +10455,7 @@ RP.Emotes = {
         "koko_male_clip",
         "Male Pose 5",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malepose3"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10939,8 +10463,7 @@ RP.Emotes = {
         "male_solo_1_clip",
         "Male Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malepose2"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10948,8 +10471,7 @@ RP.Emotes = {
         "male_solo_3_clip",
         "Male Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malepose1"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10957,8 +10479,7 @@ RP.Emotes = {
         "male_solo_4_clip",
         "Male Pose 1",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["maleshoecheck"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10966,8 +10487,7 @@ RP.Emotes = {
         "side_shoe_check_clip",
         "Male Shoe Check Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["malegangpose"] = { -- Custom Emotes By Darks Animations Provided To RPEmotes 01/08/2023
@@ -10975,8 +10495,7 @@ RP.Emotes = {
         "westside_cap_clip",
         "Male Gang Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["illuminati"] = { -- Custom Emote By EnchantedBrwny
@@ -10984,8 +10503,7 @@ RP.Emotes = {
         "ebrwny_illum003",
         "Illuminati Hand Sign",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["illuminati2"] = { -- Custom Emote By EnchantedBrwny
@@ -10993,8 +10511,7 @@ RP.Emotes = {
         "ebrwny_illum001",
         "Illuminati Hand Sign 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["illuminati3"] = { -- Custom Emote By EnchantedBrwny
@@ -11002,8 +10519,7 @@ RP.Emotes = {
         "ebrwny_illum002",
         "Illuminati Hand Sign 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gunpoint"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -11011,8 +10527,7 @@ RP.Emotes = {
         "male_gun_clip",
         "Gun Point - Robbery",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["baddiepeace"] = { -- Custom Emote provided by 41anims
@@ -11020,8 +10535,7 @@ RP.Emotes = {
         "41animpeacebaddie_clip",
         "Baddie Peace Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["baddiebendova"] = { -- Custom Emote provided by 41anims
@@ -11029,8 +10543,7 @@ RP.Emotes = {
         "bendova_clip",
         "Baddie Bendova Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["baddienailpose"] = { -- Custom Emote provided by 41anims
@@ -11038,8 +10551,7 @@ RP.Emotes = {
         "nailpose_clip",
         "Baddie Nail Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["aphroditepose"] = { -- Custom Emote provided by corbs
@@ -11047,8 +10559,7 @@ RP.Emotes = {
         "aphrodite1_clip",
         "Aphrodite Pose",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["aphroditepose2"] = { -- Custom Emote provided by corbs
@@ -11056,8 +10567,7 @@ RP.Emotes = {
         "aphrodite2_clip",
         "Aphrodite Pose 2",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["aphroditepose3"] = { -- Custom Emote provided by corbs
@@ -11065,8 +10575,7 @@ RP.Emotes = {
         "aphrodite3_clip",
         "Aphrodite Pose 3",
         AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
 
@@ -11089,8 +10598,7 @@ RP.PropEmotes = {
                 10.0,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "shakeitoffhuman",
         }
     },
@@ -11109,8 +10617,7 @@ RP.PropEmotes = {
                 -150.9605721,
                 57.3374916
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "shakeitoffhuman",
         }
     },
@@ -11129,8 +10636,7 @@ RP.PropEmotes = {
                -6.7284,
                -0.9319
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "shakeitoffhuman",
         }
     },
@@ -11149,8 +10655,7 @@ RP.PropEmotes = {
                -1.7343,
                 9.9656
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "shakeitoffhuman",
         }
     },
@@ -11185,8 +10690,7 @@ RP.PropEmotes = {
             -- EmoteLoop is used for emotes that should loop, its as simple as that.
             -- Then EmoteMoving is used for emotes that should only play on the upperbody.
             -- The code then checks both values and sets the MovementType to the correct one
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["box"] = {
@@ -11204,8 +10708,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gift"] = {
@@ -11223,7 +10726,7 @@ RP.PropEmotes = {
               -157.5768,
                -27.6738
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["gift2"] = {
@@ -11241,7 +10744,7 @@ RP.PropEmotes = {
               -157.5768,
                -27.6738
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
 	["k12saw"] = {
@@ -11259,8 +10762,7 @@ RP.PropEmotes = {
                 71.0092017,
                 83.759421
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
 			PtfxAsset = "scr_paletoscore",
             PtfxName = "scr_paleto_box_sparks",
             PtfxNoProp = true,
@@ -11293,8 +10795,7 @@ RP.PropEmotes = {
                 -178.5954846,
                 4.5961806
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["maskup"] = {
@@ -11302,8 +10803,7 @@ RP.PropEmotes = {
         "visor_up",
         "Firefighter Unmask",
         AnimationOptions = {
-			EmoteDuration = 800, -- Even with EmoteLoop = false, this emote still loops, so we add a duration to force it to stop after a set amount of milliseconds.
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
         }
     },
 	["maskdown"] = {
@@ -11311,8 +10811,7 @@ RP.PropEmotes = {
         "visor_down",
         "Firefighter Mask",
         AnimationOptions = {
-			EmoteDuration = 800, -- Even with EmoteLoop = false, this emote still loops, so we add a duration to force it to stop after a set amount of milliseconds.
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
         }
     },
     ["masktakeoff"] = {
@@ -11320,7 +10819,7 @@ RP.PropEmotes = {
         "mask_action_b",
         "Take Off Mask",
         AnimationOptions = {
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
         }
     },
 	["adjustbag"] = {
@@ -11328,7 +10827,7 @@ RP.PropEmotes = {
         "idle_b",
         "Firefighter Adjust Tank / Bag",
         AnimationOptions = {
-			EmoteMoving = true,
+			onFootFlag = AnimFlag.MOVING,
 			EmoteDuration = 9500
         }
     },
@@ -11337,8 +10836,7 @@ RP.PropEmotes = {
         "loop",
         "Firefighter Pump PSI",
         AnimationOptions = {
-            EmoteLoop = true,
-			EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cake"] = { -- Custom Prop & Emote By BzZz
@@ -11356,7 +10854,7 @@ RP.PropEmotes = {
                -245.0,
                 2.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake2"] = { -- Custom Prop & Emote By BzZz
@@ -11374,7 +10872,7 @@ RP.PropEmotes = {
                -162.0,
                 -44.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake3"] = { -- Custom Prop & Emote By BzZz
@@ -11392,7 +10890,7 @@ RP.PropEmotes = {
                -72.0,
                 -6.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake4"] = { -- Custom Prop & Emote By BzZz
@@ -11410,7 +10908,7 @@ RP.PropEmotes = {
                -72.0,
                 -6.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake5"] = {
@@ -11428,7 +10926,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake6"] = {
@@ -11446,7 +10944,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cake7"] = { -- Custom Prop By PataMods
@@ -11464,7 +10962,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cakew"] = {
@@ -11482,8 +10980,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew2"] = { -- Custom Prop & Emote By BzZz
@@ -11501,8 +10998,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew3"] = { -- Custom Prop & Emote By BzZz
@@ -11520,8 +11016,7 @@ RP.PropEmotes = {
                 0.0,
              -160.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew4"] = { -- Custom Prop & Emote By BzZz
@@ -11539,8 +11034,7 @@ RP.PropEmotes = {
                 0.0,
               180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew5"] = {
@@ -11558,8 +11052,7 @@ RP.PropEmotes = {
                 0.0,
                30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew6"] = {
@@ -11577,8 +11070,7 @@ RP.PropEmotes = {
                 0.0,
                20.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cakew7"] = { -- Custom Prop & Emote By BzZz
@@ -11596,8 +11088,7 @@ RP.PropEmotes = {
                 0.0,
                30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["rose"] = {
@@ -11615,8 +11106,7 @@ RP.PropEmotes = {
                 0.0,
                 -20.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
      },
     ["dollar"] = {
@@ -11634,8 +11124,7 @@ RP.PropEmotes = {
              -106.9746,
                 1.3733
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["balloon"] = {
@@ -11653,9 +11142,8 @@ RP.PropEmotes = {
              -101.1702,
               28.0243
             },
-            EmoteStuck = true,
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["balloon2"] = {
@@ -11673,9 +11161,8 @@ RP.PropEmotes = {
               -30.9638,
                19.3946
             },
-            EmoteStuck = true,
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["smoke2"] = {
@@ -11693,8 +11180,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -11727,8 +11213,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -11761,8 +11246,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -11795,8 +11279,7 @@ RP.PropEmotes = {
                 0.0,
                 50.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -11829,8 +11312,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -11863,8 +11345,7 @@ RP.PropEmotes = {
                 270.0,
                 -360.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_agencyheistb",
             PtfxName = "scr_agency3b_elec_box",
             PtfxNoProp = true,
@@ -11898,8 +11379,7 @@ RP.PropEmotes = {
                 110.0,
                 10.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_agencyheistb",
             PtfxName = "scr_agency3b_elec_box",
             PtfxNoProp = true,
@@ -11933,8 +11413,7 @@ RP.PropEmotes = {
                 190.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_agencyheistb",
             PtfxName = "scr_agency3b_elec_box",
             PtfxNoProp = true,
@@ -11968,8 +11447,7 @@ RP.PropEmotes = {
                 190.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_agencyheistb",
             PtfxName = "scr_agency3b_elec_box",
             PtfxNoProp = true,
@@ -12003,7 +11481,7 @@ RP.PropEmotes = {
               102.3320,
               -15.0085
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_agencyheistb",
@@ -12039,7 +11517,7 @@ RP.PropEmotes = {
               102.3320,
               -15.0085
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_agencyheistb",
@@ -12075,8 +11553,7 @@ RP.PropEmotes = {
              -131.4506,
                45.1778
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -12109,8 +11586,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["fishing2"] = {
@@ -12128,8 +11604,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["fishing3"] = {
@@ -12147,8 +11622,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["icefishing"] = { -- Custom Emote By EP
@@ -12166,8 +11640,7 @@ RP.PropEmotes = {
                 0.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["icefishing2"] = { -- Custom Emote By EP
@@ -12195,8 +11668,7 @@ RP.PropEmotes = {
                 90.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["suitcase"] = {
@@ -12214,8 +11686,7 @@ RP.PropEmotes = {
                 266.0,
                 90.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["suitcase2"] = {
@@ -12233,8 +11704,7 @@ RP.PropEmotes = {
                 280.0,
                 90.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["boombox"] = {
@@ -12252,8 +11722,7 @@ RP.PropEmotes = {
                 263.0,
                 58.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["boombox2"] = {
@@ -12281,8 +11750,7 @@ RP.PropEmotes = {
                 176.7406,
                 23.0190
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["toolbox"] = {
@@ -12300,8 +11768,7 @@ RP.PropEmotes = {
                 0.0,
                 90.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["toolbox2"] = {
@@ -12319,8 +11786,7 @@ RP.PropEmotes = {
                 0.0,
               -90.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["toolbox3"] = {
@@ -12338,8 +11804,7 @@ RP.PropEmotes = {
                 0.0,
               -90.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["toolbox4"] = {
@@ -12357,8 +11822,7 @@ RP.PropEmotes = {
                 0.0,
               -90.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
      },
     ["cashbox"] = {
@@ -12376,8 +11840,7 @@ RP.PropEmotes = {
                 0.0,
               -81.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbag"] = {
@@ -12395,8 +11858,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beerbox"] = {
@@ -12414,8 +11876,7 @@ RP.PropEmotes = {
                 266.0,
                 48.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beerbox2"] = {
@@ -12433,8 +11894,7 @@ RP.PropEmotes = {
                 266.0,
                 48.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beerbox3"] = {
@@ -12452,8 +11912,7 @@ RP.PropEmotes = {
                 266.0,
                 48.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beerbox4"] = {
@@ -12471,8 +11930,7 @@ RP.PropEmotes = {
                 266.0,
                 60.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mugshot"] = {
@@ -12490,8 +11948,7 @@ RP.PropEmotes = {
                 0.0,
                 70.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["coffee"] = {
@@ -12509,8 +11966,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["coffeecall"] = {
@@ -12547,8 +12003,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["whiskey"] = {
@@ -12566,8 +12021,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["whiskeyb"] = {
@@ -12585,8 +12039,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beer"] = {
@@ -12604,8 +12057,7 @@ RP.PropEmotes = {
                 15.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beer2"] = {
@@ -12623,8 +12075,7 @@ RP.PropEmotes = {
                 15.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beer3"] = {
@@ -12642,8 +12093,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beer4"] = {
@@ -12661,8 +12111,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["beer5"] = {
@@ -12680,8 +12129,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["whiskeyb2"] = {
@@ -12699,8 +12147,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["whiskeyb3"] = {
@@ -12718,8 +12165,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["beerf"] = {
@@ -12737,8 +12183,7 @@ RP.PropEmotes = {
                 15.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beercan"] = {
@@ -12756,8 +12201,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beercan2"] = {
@@ -12775,8 +12219,7 @@ RP.PropEmotes = {
                 0.0,
              -150.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beercan3"] = {
@@ -12794,8 +12237,7 @@ RP.PropEmotes = {
                 0.0,
                 90.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wine2"] = {
@@ -12813,8 +12255,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             --       PropPlacement = {-0.0, 0.03, -0.20, 5.0, 0.0, 0.0},
             --     F&B   L&R   U&D  R.F&B
         }
@@ -12834,8 +12275,7 @@ RP.PropEmotes = {
                 15.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["beerf4"] = {
@@ -12853,8 +12293,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["beerf5"] = {
@@ -12872,8 +12311,7 @@ RP.PropEmotes = {
                 15.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["wine3"] = {
@@ -12891,8 +12329,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["cup"] = {
@@ -12910,8 +12347,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["apple"] = {
@@ -12929,7 +12365,7 @@ RP.PropEmotes = {
                 -166.5760,
                 8.4572
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["taco"] = {
@@ -12947,7 +12383,7 @@ RP.PropEmotes = {
                 -105.0251,
                 55.7779
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["hotdog"] = {
@@ -12965,7 +12401,7 @@ RP.PropEmotes = {
                 94.7001,
                 -66.9179
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["bagel"] = {
@@ -12983,7 +12419,7 @@ RP.PropEmotes = {
               -53.8984,
                 4.8412
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["donut"] = {
@@ -13001,7 +12437,7 @@ RP.PropEmotes = {
                 16.0,
                 60.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["donut2"] = { -- Custom Prop by BzZz
@@ -13019,7 +12455,7 @@ RP.PropEmotes = {
                 0.0000,
                 -1.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["donut3"] = { -- Custom Prop by BzZz
@@ -13037,7 +12473,7 @@ RP.PropEmotes = {
                 0.0000,
                 -1.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["desert"] = { -- Custom Prop by BzZz
@@ -13055,7 +12491,7 @@ RP.PropEmotes = {
                 -36.0,
                 0.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["croissant"] = { -- Custom Prop by BzZz
@@ -13073,7 +12509,7 @@ RP.PropEmotes = {
                 0.0000,
                 90.0000
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["gingerbread"] = { -- Custom Prop by BzZz
@@ -13091,7 +12527,7 @@ RP.PropEmotes = {
                 164.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candycane"] = { -- Custom Prop by BzZz
@@ -13109,7 +12545,7 @@ RP.PropEmotes = {
                 146.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candycaneb"] = { -- Custom Prop by BzZz
@@ -13127,7 +12563,7 @@ RP.PropEmotes = {
                 146.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candycanec"] = { -- Custom Prop by BzZz
@@ -13145,7 +12581,7 @@ RP.PropEmotes = {
                 146.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candycaned"] = { -- Custom Prop by BzZz
@@ -13163,7 +12599,7 @@ RP.PropEmotes = {
                 146.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candycanee"] = { -- Custom Prop by BzZz
@@ -13181,7 +12617,7 @@ RP.PropEmotes = {
                 146.0,
                 -5.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["meat"] = {
@@ -13199,8 +12635,7 @@ RP.PropEmotes = {
              -30.9089,
               60.0374
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["meat2"] = {
@@ -13218,8 +12653,7 @@ RP.PropEmotes = {
              -80.0,
                9.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow"] = {
@@ -13237,8 +12671,7 @@ RP.PropEmotes = {
              -30.9089,
               60.0374
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow2"] = {
@@ -13256,8 +12689,7 @@ RP.PropEmotes = {
              -30.9089,
               60.0374
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow3"] = {
@@ -13275,8 +12707,7 @@ RP.PropEmotes = {
              -30.9089,
               60.0374
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow4"] = {
@@ -13294,8 +12725,7 @@ RP.PropEmotes = {
              -80.0,
                9.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow5"] = {
@@ -13313,8 +12743,7 @@ RP.PropEmotes = {
              -80.0,
                9.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mallow6"] = {
@@ -13332,8 +12761,7 @@ RP.PropEmotes = {
              -80.0,
                9.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["macaroon"] = { -- Custom Prop by BzZz
@@ -13351,7 +12779,7 @@ RP.PropEmotes = {
                 7.0,
                 7.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmasmug"] = { -- Custom Prop by BzZz
@@ -13369,7 +12797,7 @@ RP.PropEmotes = {
                 137.0,
                 9.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmasmug2"] = { -- Custom Prop by BzZz
@@ -13387,7 +12815,7 @@ RP.PropEmotes = {
                 137.0,
                 9.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmaswine"] = { -- Custom Prop by BzZz
@@ -13405,7 +12833,7 @@ RP.PropEmotes = {
                -47.0,
                 7.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cocoa"] = {
@@ -13423,8 +12851,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["xmassf"] = { -- Custom Prop by PataMods
@@ -13442,7 +12869,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmascc"] = { -- Custom Prop by PataMods
@@ -13460,7 +12887,7 @@ RP.PropEmotes = {
                 87.6716,
                 30.0540
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmascc2"] = { -- Custom Prop by PataMods
@@ -13478,7 +12905,7 @@ RP.PropEmotes = {
               -90.1809,
                66.3689
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["xmasic"] = {
@@ -13506,8 +12933,7 @@ RP.PropEmotes = {
                20.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pizzaslice"] = { -- Custom Prop by knjgh
@@ -13525,7 +12951,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["pizzas"] = { -- Custom Prop by knjgh
@@ -13543,7 +12969,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["pizzas2"] = { -- Custom Prop by knjgh
@@ -13561,7 +12987,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["pizzas3"] = { -- Custom Prop by knjgh
@@ -13579,7 +13005,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["pizzas4"] = { -- Custom Prop by knjgh
@@ -13597,7 +13023,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["pizzas5"] = { -- Custom Prop by knjgh
@@ -13615,7 +13041,7 @@ RP.PropEmotes = {
                 -66.7427,
                 68.3677
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["eat"] = {
@@ -13633,7 +13059,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000,
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["burger"] = {
@@ -13651,7 +13077,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000,
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["burgerpose"] = { -- Custom Emote By Dark Animations exclusive to RPEmotes exclusive to RPEmotes
@@ -13679,8 +13105,7 @@ RP.PropEmotes = {
              -169.3724,
                19.6834
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sandwich"] = {
@@ -13698,7 +13123,7 @@ RP.PropEmotes = {
                 16.0,
                 60.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["soda"] = {
@@ -13716,8 +13141,7 @@ RP.PropEmotes = {
                 0.0,
                 130.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda2"] = {
@@ -13735,8 +13159,7 @@ RP.PropEmotes = {
                 0.0,
                 160.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["soda3"] = {
@@ -13754,8 +13177,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda4"] = {
@@ -13773,8 +13195,7 @@ RP.PropEmotes = {
                 0.0,
              -150.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda5"] = {
@@ -13792,8 +13213,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda6"] = {
@@ -13811,8 +13231,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda7"] = {
@@ -13830,8 +13249,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["soda8"] = {
@@ -13849,8 +13267,7 @@ RP.PropEmotes = {
                 0.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["soda9"] = {
@@ -13868,8 +13285,7 @@ RP.PropEmotes = {
                 0.0,
                 130.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["boba"] = {
@@ -13887,8 +13303,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["boba2"] = {
@@ -13906,8 +13321,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["boba3"] = {
@@ -13925,8 +13339,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sipsoda"] = {
@@ -13944,8 +13357,7 @@ RP.PropEmotes = {
             -25.0367,
             -27.3898
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sipsodab"] = {
@@ -13963,8 +13375,7 @@ RP.PropEmotes = {
             -25.0367,
             -27.3898
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sipsodac"] = {
@@ -13982,8 +13393,7 @@ RP.PropEmotes = {
             -25.0367,
             -27.3898
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sipsodad"] = {
@@ -14001,8 +13411,7 @@ RP.PropEmotes = {
             -25.0367,
             -27.3898
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dbsoda"] = {
@@ -14020,8 +13429,7 @@ RP.PropEmotes = {
               180.0000,
               -10.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mojito"] = {
@@ -14039,8 +13447,7 @@ RP.PropEmotes = {
                 0.0000,
               130.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["frappe"] = {
@@ -14058,8 +13465,7 @@ RP.PropEmotes = {
                -3.9999,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["frappe2"] = {
@@ -14077,8 +13483,7 @@ RP.PropEmotes = {
                 0.0,
              -140.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["frappe3"] = {
@@ -14096,8 +13501,7 @@ RP.PropEmotes = {
                 0.0,
              -178.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["frappe4"] = {
@@ -14115,8 +13519,7 @@ RP.PropEmotes = {
                 0.0,
              -178.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["edrink"] = {
@@ -14135,8 +13538,7 @@ RP.PropEmotes = {
                 4.6611,
               -49.9065
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["edrink2"] = {
@@ -14155,8 +13557,7 @@ RP.PropEmotes = {
                 0.0,
              -110.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["edrink3"] = {
@@ -14175,8 +13576,7 @@ RP.PropEmotes = {
                 0.0000,
                 9.0000
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mshake"] = {
@@ -14194,8 +13594,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakeb"] = {
@@ -14213,8 +13612,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakec"] = {
@@ -14232,8 +13630,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshaked"] = {
@@ -14251,8 +13648,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakee"] = {
@@ -14270,8 +13666,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakef"] = {
@@ -14289,8 +13684,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakeg"] = {
@@ -14308,8 +13702,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakeh"] = {
@@ -14327,8 +13720,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakei"] = {
@@ -14346,8 +13738,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakej"] = {
@@ -14365,8 +13756,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakek"] = {
@@ -14384,8 +13774,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["mshakel"] = {
@@ -14403,8 +13792,7 @@ RP.PropEmotes = {
                -180.0,
                  30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshake"] = {
@@ -14422,8 +13810,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakeb"] = {
@@ -14441,8 +13828,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakec"] = {
@@ -14460,8 +13846,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshaked"] = {
@@ -14479,8 +13864,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakee"] = {
@@ -14498,8 +13882,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakef"] = {
@@ -14517,8 +13900,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakeg"] = {
@@ -14536,8 +13918,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakeh"] = {
@@ -14555,8 +13936,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakei"] = {
@@ -14574,8 +13954,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakej"] = {
@@ -14593,8 +13972,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakek"] = {
@@ -14612,8 +13990,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["sipshakel"] = {
@@ -14631,8 +14008,7 @@ RP.PropEmotes = {
             -165.7841,
               24.1318
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sodafu"] = {
@@ -14650,8 +14026,7 @@ RP.PropEmotes = {
                 0.000,
               -69.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sodafu2"] = {
@@ -14669,8 +14044,7 @@ RP.PropEmotes = {
                 0.000,
                 0.000,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["water"] = {
@@ -14689,8 +14063,7 @@ RP.PropEmotes = {
                 0.0,
               -40.0000
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["egobar"] = {
@@ -14708,7 +14081,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["candy"] = {
@@ -14726,7 +14099,7 @@ RP.PropEmotes = {
                 180.0,
                 -88.099
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1"] = {
@@ -14744,7 +14117,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1b"] = {
@@ -14762,7 +14135,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1c"] = {
@@ -14780,7 +14153,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1d"] = {
@@ -14798,7 +14171,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1e"] = {
@@ -14816,7 +14189,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop1f"] = {
@@ -14834,7 +14207,7 @@ RP.PropEmotes = {
                 97.6975,
                 20.9598
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["lollipop2a"] = {
@@ -14852,8 +14225,7 @@ RP.PropEmotes = {
                 -128.8559,
                 15.6107
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lollipop2b"] = {
@@ -14871,8 +14243,7 @@ RP.PropEmotes = {
                 -128.8559,
                 15.6107
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lollipop2c"] = {
@@ -14890,8 +14261,7 @@ RP.PropEmotes = {
                 -128.8559,
                 15.6107
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lollipop2d"] = {
@@ -14909,8 +14279,7 @@ RP.PropEmotes = {
                 -128.8559,
                 15.6107
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lollipop2e"] = {
@@ -14928,8 +14297,7 @@ RP.PropEmotes = {
                 -128.8559,
                 15.6107
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lollipop3a"] = {
@@ -14947,7 +14315,7 @@ RP.PropEmotes = {
                 10.0000,
                 -10.0000
             },
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2600
         }
     },
@@ -14966,7 +14334,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamb"] = {
@@ -14984,7 +14352,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamc"] = {
@@ -15002,7 +14370,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamd"] = {
@@ -15020,7 +14388,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreame"] = {
@@ -15038,7 +14406,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamf"] = {
@@ -15056,7 +14424,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamg"] = {
@@ -15074,7 +14442,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["icecreamh"] = {
@@ -15092,7 +14460,7 @@ RP.PropEmotes = {
                 70.0,
                 -203.0
             },
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["wine"] = {
@@ -15110,8 +14478,7 @@ RP.PropEmotes = {
                 0.0,
                 -10.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["flute"] = {
@@ -15129,8 +14496,7 @@ RP.PropEmotes = {
                 0.0,
                 -10.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["champagne"] = {
@@ -15148,8 +14514,7 @@ RP.PropEmotes = {
                 0.0,
                 -10.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cigar"] = {
@@ -15168,8 +14533,7 @@ RP.PropEmotes = {
                 -80.0
             },
             EmoteDuration = 2600,
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -15203,8 +14567,7 @@ RP.PropEmotes = {
                -80.0
             },
             EmoteDuration = 2600,
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -15237,8 +14600,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitar2"] = {
@@ -15256,8 +14618,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitar3"] = {
@@ -15275,8 +14636,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitar4"] = {
@@ -15294,8 +14654,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitar5"] = {
@@ -15313,8 +14672,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitar6"] = {
@@ -15332,8 +14690,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarelectric"] = {
@@ -15351,8 +14708,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarelectric2"] = {
@@ -15370,8 +14726,7 @@ RP.PropEmotes = {
                 20.0,
                 150.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry"] = {
@@ -15389,8 +14744,7 @@ RP.PropEmotes = {
                 0.0,
                 15.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry2"] = {
@@ -15408,8 +14762,7 @@ RP.PropEmotes = {
                 5.7251,
                 29.4987
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
     ["guitarcarry3"] = {
@@ -15427,8 +14780,7 @@ RP.PropEmotes = {
                 5.7251,
                 29.4987
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry4"] = {
@@ -15446,8 +14798,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry5"] = {
@@ -15465,8 +14816,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry6"] = {
@@ -15484,8 +14834,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry7"] = {
@@ -15503,8 +14852,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry8"] = {
@@ -15522,8 +14870,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarcarry9"] = {
@@ -15541,8 +14888,7 @@ RP.PropEmotes = {
                 0.0,
                 21.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guitarsit"] = {
@@ -15560,7 +14906,7 @@ RP.PropEmotes = {
                 166.3300,
                 29.7590
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -15579,7 +14925,7 @@ RP.PropEmotes = {
                 166.3300,
                 29.7590
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -15598,7 +14944,7 @@ RP.PropEmotes = {
                 166.3300,
                 29.7590
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -15618,8 +14964,7 @@ RP.PropEmotes = {
                 90.0
             },
             -- This positioning isnt too great, was to much of a hassle
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bookb"] = {
@@ -15637,8 +14982,7 @@ RP.PropEmotes = {
               158.5623,
                24.7080,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bookc"] = {
@@ -15666,8 +15010,7 @@ RP.PropEmotes = {
               176.3905,
               19.3724
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bookd"] = {
@@ -15685,8 +15028,7 @@ RP.PropEmotes = {
                 0.0000,
               -15.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["booke"] = {
@@ -15704,8 +15046,7 @@ RP.PropEmotes = {
                 3.1232,
               -21.2448
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bookf"] = {
@@ -15723,7 +15064,7 @@ RP.PropEmotes = {
               -14.2960,
                28.8727
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -15742,8 +15083,7 @@ RP.PropEmotes = {
               121.0529,
               -11.7724
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bouquet2"] = {
@@ -15761,8 +15101,7 @@ RP.PropEmotes = {
                60.1852,
                 3.4934
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["teddy"] = {
@@ -15780,8 +15119,7 @@ RP.PropEmotes = {
                 -90.0,
                 0.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["backpack"] = {
@@ -15799,8 +15137,7 @@ RP.PropEmotes = {
                 90.0,
                 175.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["clipboard"] = {
@@ -15818,8 +15155,7 @@ RP.PropEmotes = {
                 -50.0,
                 0.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["map"] = {
@@ -15837,8 +15173,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["map2"] = {
@@ -15856,8 +15191,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beg"] = {
@@ -15875,8 +15209,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beg2"] = {
@@ -15894,8 +15227,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beg3"] = {
@@ -15913,8 +15245,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beg4"] = {
@@ -15932,8 +15263,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newspaper"] = {
@@ -15951,8 +15281,7 @@ RP.PropEmotes = {
                 3.2712,
                 -10.5080
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newspaper2"] = {
@@ -15970,8 +15299,7 @@ RP.PropEmotes = {
                 0.0087,
                 0.5000
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newspaper3"] = {
@@ -15989,8 +15317,7 @@ RP.PropEmotes = {
                 3.2841,
                 -4.7185
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pornmag"] = {
@@ -16008,8 +15335,7 @@ RP.PropEmotes = {
                 179.2527,
                 13.8804
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16028,8 +15354,7 @@ RP.PropEmotes = {
                 -0.4292,
                 -14.3925
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16048,8 +15373,7 @@ RP.PropEmotes = {
                 -180.0000,
                 22.7007
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16068,8 +15392,7 @@ RP.PropEmotes = {
                 0.2032,
                 -20.0016
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16088,8 +15411,7 @@ RP.PropEmotes = {
                 0.2032,
                 -20.0016
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16108,8 +15430,7 @@ RP.PropEmotes = {
                 0.2032,
                 -20.0016
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16128,8 +15449,7 @@ RP.PropEmotes = {
                 0.2032,
                 -20.0016
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -16148,8 +15468,7 @@ RP.PropEmotes = {
                 0.0,
                 70.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_xs_celebration",
             PtfxName = "scr_xs_money_rain",
             PtfxPlacement = {
@@ -16181,8 +15500,7 @@ RP.PropEmotes = {
                 33.0998,
                 4.1917
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_bike_business",
             PtfxName = "scr_bike_cfid_camera_flash",
             PtfxPlacement = {
@@ -16213,8 +15531,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_bike_business",
             PtfxName = "scr_bike_cfid_camera_flash",
             PtfxPlacement = {
@@ -16245,8 +15562,7 @@ RP.PropEmotes = {
                 -163.9389,
                 -29.0221
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_bike_business",
             PtfxName = "scr_bike_cfid_camera_flash",
             PtfxPlacement = {
@@ -16277,8 +15593,7 @@ RP.PropEmotes = {
                99.6144,
                 2.9027
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_bike_business",
             PtfxName = "scr_bike_cfid_camera_flash",
             PtfxPlacement = {
@@ -16309,8 +15624,7 @@ RP.PropEmotes = {
               107.0825,
               -16.0159
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_bike_business",
             PtfxName = "scr_bike_cfid_camera_flash",
             PtfxPlacement = {
@@ -16341,8 +15655,7 @@ RP.PropEmotes = {
               176.0000,
                79.9999
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["champagnespray"] = {
@@ -16360,8 +15673,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_ba_club",
             PtfxName = "scr_ba_club_champagne_spray",
             PtfxPlacement = {
@@ -16392,7 +15704,7 @@ RP.PropEmotes = {
                 0.0,
                 110.0
             },
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             EmoteDuration = 2600,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
@@ -16427,8 +15739,7 @@ RP.PropEmotes = {
                 110.0
             },
             EmoteDuration = 2600,
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -16461,8 +15772,7 @@ RP.PropEmotes = {
                 255.0,
                 80.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["brief2"] = { -- Added for compatibility
@@ -16481,8 +15791,7 @@ RP.PropEmotes = {
                 280.0,
                 53.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["brushteeth"] = {
@@ -16501,8 +15810,7 @@ RP.PropEmotes = {
                 -159.0,
                 26.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["guncase"] = {
@@ -16521,8 +15829,7 @@ RP.PropEmotes = {
                 145.0,
                 115.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tablet"] = {
@@ -16540,8 +15847,7 @@ RP.PropEmotes = {
                 -90.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tablet2"] = {
@@ -16559,8 +15865,7 @@ RP.PropEmotes = {
                 -90.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["phonecall"] = {
@@ -16588,8 +15893,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["phonecall2"] = {
@@ -16617,8 +15921,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wt"] = {
@@ -16636,8 +15939,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["wt2"] = {
@@ -16655,7 +15957,7 @@ RP.PropEmotes = {
                 3.7058,
                 -23.2367
 				},
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
 
         }
     },
@@ -16674,8 +15976,7 @@ RP.PropEmotes = {
                 3.7058,
                 -23.2367
 				},
-            EmoteLoop = true,
-			EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["wt4"] = {
@@ -16693,8 +15994,7 @@ RP.PropEmotes = {
                 0.0,
               -59.9999
 				},
-            EmoteLoop = true,
-			EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["clean"] = {
@@ -16712,8 +16012,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["clean2"] = {
@@ -16731,8 +16030,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["protest"] = {
@@ -16751,8 +16049,7 @@ RP.PropEmotes = {
                 -13.9572354
             },
             --
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["protest2"] = {
@@ -16770,8 +16067,7 @@ RP.PropEmotes = {
                 5.9142048,
                 -13.9572354
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["protest3"] = {
@@ -16789,8 +16085,7 @@ RP.PropEmotes = {
                 5.914205,
                 -13.957235
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["binoculars"] = {
@@ -16808,8 +16103,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["binoculars2"] = {
@@ -16827,8 +16121,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tennisplay"] = {
@@ -16856,8 +16149,7 @@ RP.PropEmotes = {
                 3.8782324,
                 6.588224
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weights"] = {
@@ -16875,8 +16167,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weights2"] = {
@@ -16894,8 +16185,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weights3"] = { -- Custom Emote By Amnilka
@@ -16913,7 +16203,7 @@ RP.PropEmotes = {
                 90.0000,
                 -79.9999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["weights4"] = { -- Custom Emote By Amnilka
@@ -16941,7 +16231,7 @@ RP.PropEmotes = {
                 90.0000,
                 -79.9999
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["weights5"] = { -- Custom Female Emote By Frabi
@@ -16969,7 +16259,7 @@ RP.PropEmotes = {
                 -128.5627,
                 13.7517
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["weights6"] = { -- Custom Female Emote By Frabi
@@ -16997,8 +16287,7 @@ RP.PropEmotes = {
                 -15.0123,
                 0.5710
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["weights7"] = { -- Custom Female Emote By Frabi
@@ -17016,8 +16305,7 @@ RP.PropEmotes = {
                 -51.8805,
                 54.3903
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["fuel"] = {
@@ -17035,8 +16323,7 @@ RP.PropEmotes = {
                 -11.2122753,
                 -32.9453021
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["fuel2"] = {
@@ -17054,8 +16341,7 @@ RP.PropEmotes = {
                 180.000,
                 79.99
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["hitchhike"] = {
@@ -17083,8 +16369,7 @@ RP.PropEmotes = {
                 117.358,
                 -6.16
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign"] = {
@@ -17102,8 +16387,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign2"] = {
@@ -17121,8 +16405,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign3"] = {
@@ -17140,8 +16423,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign4"] = {
@@ -17159,8 +16441,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign5"] = {
@@ -17178,8 +16459,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign6"] = {
@@ -17197,8 +16477,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign7"] = {
@@ -17216,8 +16495,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign8"] = {
@@ -17235,8 +16513,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["ssign9"] = {
@@ -17254,8 +16531,7 @@ RP.PropEmotes = {
                 145.0627869,
                 -4.4318885
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stire"] = {
@@ -17273,8 +16549,7 @@ RP.PropEmotes = {
                 -80.0,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stire2"] = {
@@ -17292,8 +16567,7 @@ RP.PropEmotes = {
                 -80.0,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["conehead"] = {
@@ -17311,8 +16585,7 @@ RP.PropEmotes = {
                 90.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtraya"] = {
@@ -17330,8 +16603,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayb"] = {
@@ -17349,8 +16621,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayc"] = {
@@ -17368,8 +16639,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayd"] = {
@@ -17387,8 +16657,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtraye"] = {
@@ -17406,8 +16675,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayf"] = {
@@ -17435,8 +16703,7 @@ RP.PropEmotes = {
                 110.2074758,
                 -3.5886263
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayg"] = {
@@ -17464,8 +16731,7 @@ RP.PropEmotes = {
                 110.2074758,
                 -3.5886263
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayh"] = {
@@ -17493,8 +16759,7 @@ RP.PropEmotes = {
                 110.2074758,
                 -3.5886263
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayi"] = {
@@ -17522,8 +16787,7 @@ RP.PropEmotes = {
                 110.2074758,
                 -3.5886263
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayj"] = {
@@ -17541,8 +16805,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayk"] = {
@@ -17560,8 +16823,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayl"] = {
@@ -17579,8 +16841,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtraym"] = {
@@ -17598,8 +16859,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayn"] = {
@@ -17617,8 +16877,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["foodtrayo"] = {
@@ -17636,8 +16895,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mnc"] = {
@@ -17665,8 +16923,7 @@ RP.PropEmotes = {
              -176.2526,
               -28.4674
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carrypizza"] = {
@@ -17684,8 +16941,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carryfoodbag"] = {
@@ -17703,8 +16959,7 @@ RP.PropEmotes = {
                 -79.9999997,
                 110.0651988
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carryfoodbag2"] = {
@@ -17722,8 +16977,7 @@ RP.PropEmotes = {
                 -79.9999997,
                 110.0651988
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["carryfoodbag3"] = {
@@ -17741,8 +16995,7 @@ RP.PropEmotes = {
                 -79.9999997,
                 110.0651988
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag"] = {
@@ -17760,8 +17013,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag2"] = {
@@ -17779,8 +17031,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag3"] = {
@@ -17798,8 +17049,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag4"] = {
@@ -17817,8 +17067,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag5"] = {
@@ -17836,8 +17085,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag6"] = {
@@ -17855,8 +17103,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["tag7"] = {
@@ -17874,8 +17121,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beans"] = {
@@ -17903,8 +17149,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pho"] = {
@@ -17932,8 +17177,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dinner"] = {
@@ -17960,8 +17204,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newscam"] = {
@@ -17979,8 +17222,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newsmic"] = {
@@ -17998,8 +17240,7 @@ RP.PropEmotes = {
                 0.0,
                 60.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["newsbmic"] = {
@@ -18017,8 +17258,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microck"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18036,8 +17276,7 @@ RP.PropEmotes = {
                 -91.1712,
                 -3.8249
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckb"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18055,8 +17294,7 @@ RP.PropEmotes = {
               -13.0000,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckc"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18074,8 +17312,7 @@ RP.PropEmotes = {
                 -91.1712,
                 -3.8249
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckd"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18093,8 +17330,7 @@ RP.PropEmotes = {
                 -91.1712,
                 -3.8249
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microcke"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18112,8 +17348,7 @@ RP.PropEmotes = {
                -93.5253,
                 4.6450
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckf"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18131,8 +17366,7 @@ RP.PropEmotes = {
                 51.8164,
                 3.0976
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckg"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18150,8 +17384,7 @@ RP.PropEmotes = {
                 36.3684,
                 -11.7503
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckh"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18169,8 +17402,7 @@ RP.PropEmotes = {
                -93.5253,
                 4.6450
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microcki"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18188,8 +17420,7 @@ RP.PropEmotes = {
                 -91.1712,
                 -3.8249
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["microckj"] = { -- Custom Emote Provided To RpEmotes By Prue颜
@@ -18207,8 +17438,7 @@ RP.PropEmotes = {
                 -91.1712,
                 -3.8249
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leafblower"] = {
@@ -18226,8 +17456,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_armenian3",
             PtfxName = "ent_anim_leaf_blower",
             PtfxPlacement = {
@@ -18259,8 +17488,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pump"] = {
@@ -18278,8 +17506,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pump2"] = {
@@ -18297,8 +17524,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pump3"] = {
@@ -18316,8 +17542,7 @@ RP.PropEmotes = {
                 179.8707,
                 -39.9860
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pump4"] = {
@@ -18335,8 +17560,7 @@ RP.PropEmotes = {
                 179.8707,
                 -39.9860
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["pump5"] = {
@@ -18354,8 +17578,7 @@ RP.PropEmotes = {
                 179.8707,
                 -39.9860
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mop"] = {
@@ -18373,8 +17596,7 @@ RP.PropEmotes = {
                 10.3568,
                 17.9681
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mop2"] = {
@@ -18392,8 +17614,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["jerkf"] = {
@@ -18411,8 +17632,7 @@ RP.PropEmotes = {
                 80.0,
                 30.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -18431,7 +17651,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["rake2"] = {
@@ -18449,7 +17669,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["rake3"] = {
@@ -18467,7 +17687,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["rake4"] = {
@@ -18485,7 +17705,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["broom"] = {
@@ -18503,8 +17723,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["broom2"] = {
@@ -18522,8 +17741,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["broom3"] = {
@@ -18541,8 +17759,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["broom4"] = {
@@ -18560,8 +17777,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["champw"] = {
@@ -18589,8 +17805,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shit"] = {
@@ -18609,8 +17824,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_poo",
             PtfxNoProp = true,
@@ -18645,8 +17859,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_amb_chop",
             PtfxName = "ent_anim_dog_poo",
             PtfxNoProp = true,
@@ -18670,8 +17883,7 @@ RP.PropEmotes = {
     "cross_arms_clip",
     "Puke",
     AnimationOptions = {
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_paletoscore",
             PtfxName = "scr_trev_puke",
             PtfxNoProp = true,
@@ -18695,8 +17907,7 @@ RP.PropEmotes = {
         "trv_puking_leadout",
         "Puke 2",
         AnimationOptions = {
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_paletoscore",
             PtfxName = "scr_trev_puke",
             PtfxNoProp = true,
@@ -18720,7 +17931,7 @@ RP.PropEmotes = {
         "idle",
         "Puke 3",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_paletoscore",
             PtfxName = "scr_trev_puke",
             PtfxNoProp = true,
@@ -18744,7 +17955,7 @@ RP.PropEmotes = {
         "vomit",
         "Puke 4",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_paletoscore",
             PtfxName = "scr_trev_puke",
             PtfxNoProp = true,
@@ -18788,8 +17999,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -18830,8 +18040,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -18872,8 +18081,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -18914,8 +18122,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -18956,8 +18163,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -18998,8 +18204,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19040,8 +18245,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19082,8 +18286,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19124,8 +18327,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19166,8 +18368,7 @@ RP.PropEmotes = {
                 9.8904,
               -18.1951
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19208,8 +18409,7 @@ RP.PropEmotes = {
                 -139.9058,
                 35.6203
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19250,8 +18450,7 @@ RP.PropEmotes = {
                 -67.8240,
                 -46.0417
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19292,8 +18491,7 @@ RP.PropEmotes = {
                 0.0000,
                 -25.9000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19336,8 +18534,7 @@ RP.PropEmotes = {
                 0.0,
                 -150.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19378,8 +18575,7 @@ RP.PropEmotes = {
                 -67.8240,
                 -46.0417
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19420,8 +18616,7 @@ RP.PropEmotes = {
                 30.4351,
                 -7.9339
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19462,8 +18657,7 @@ RP.PropEmotes = {
               180.0000,
                -8.8999
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19506,8 +18700,7 @@ RP.PropEmotes = {
                 -180.0000,
                 10.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["selfiesit2"] = { -- Emote by WolfSquareEmotes
@@ -19535,8 +18728,7 @@ RP.PropEmotes = {
                -11.0026,
                 18.2605
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19577,8 +18769,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19621,8 +18812,7 @@ RP.PropEmotes = {
                  9.4080,
                 -3.4048
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19663,8 +18853,7 @@ RP.PropEmotes = {
                -117.2863,
                 17.0148
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19707,8 +18896,7 @@ RP.PropEmotes = {
                 -4.9809,
                 109.6216
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19749,8 +18937,7 @@ RP.PropEmotes = {
                 -99.4080,
                 -3.4048
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19793,8 +18980,7 @@ RP.PropEmotes = {
                 -82.9040,
                 -18.7472
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19837,8 +19023,7 @@ RP.PropEmotes = {
                54.9374,
                -6.1611
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -19904,7 +19089,7 @@ RP.PropEmotes = {
             },
             PtfxInfo = Translate('camera'),
             PtfxWait = 200,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -19933,8 +19118,7 @@ RP.PropEmotes = {
                 0.0,
                 170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -19975,8 +19159,7 @@ RP.PropEmotes = {
                -149.6187,
                 8.6491
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20017,8 +19200,7 @@ RP.PropEmotes = {
                -149.6187,
                 8.6491
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20059,8 +19241,7 @@ RP.PropEmotes = {
                -149.6187,
                 8.6491
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20101,8 +19282,7 @@ RP.PropEmotes = {
                -149.6187,
                 8.6491
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20143,8 +19323,7 @@ RP.PropEmotes = {
                 0.0000,
                 10.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20185,8 +19364,7 @@ RP.PropEmotes = {
                 -84.4828,
                 4.7551
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20227,8 +19405,7 @@ RP.PropEmotes = {
                 3.9999,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20269,8 +19446,7 @@ RP.PropEmotes = {
                 67.8030,
                 6.1827
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20311,8 +19487,7 @@ RP.PropEmotes = {
                 41.8372,
                 -26.6415
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20353,8 +19528,7 @@ RP.PropEmotes = {
                 47.2288,
                -14.9588
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20405,8 +19579,7 @@ RP.PropEmotes = {
                 30.6141,
                -5.1311
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20447,8 +19620,7 @@ RP.PropEmotes = {
                 180.0000,
                 13.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20489,8 +19661,7 @@ RP.PropEmotes = {
                -180.0000,
                 0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20541,8 +19712,7 @@ RP.PropEmotes = {
                 13.7526,
                 2.6457
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -20586,8 +19756,7 @@ RP.PropEmotes = {
                 -92.4142,
                 33.1691
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20628,7 +19797,7 @@ RP.PropEmotes = {
                -174.8342,
                 -8.4770
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20679,8 +19848,7 @@ RP.PropEmotes = {
                 -24.7476,
                  13.7795
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -20721,8 +19889,7 @@ RP.PropEmotes = {
            -54.5014945,
            -12.0985177
         },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         PtfxAsset = "scr_tn_meet",
         PtfxName = "scr_tn_meet_phone_camera_flash",
         PtfxPlacement = {
@@ -20763,8 +19930,7 @@ RP.PropEmotes = {
           33.2648588,
           18.6732448
     },
-    EmoteLoop = true,
-    EmoteMoving = false,
+    onFootFlag = AnimFlag.LOOP,
     PtfxAsset = "scr_tn_meet",
     PtfxName = "scr_tn_meet_phone_camera_flash",
     PtfxPlacement = {
@@ -20795,8 +19961,7 @@ RP.PropEmotes = {
             157.9882355,
             80.8053557
         },
-        EmoteLoop = true,
-        EmoteMoving = true,
+        onFootFlag = AnimFlag.MOVING,
         PtfxAsset = "scr_bike_business",
         PtfxName = "scr_bike_cfid_camera_flash",
         PtfxPlacement = {
@@ -20837,8 +20002,7 @@ RP.PropEmotes = {
             3.367247,
             0.0711684
         },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         PtfxAsset = "scr_tn_meet",
         PtfxName = "scr_tn_meet_phone_camera_flash",
         PtfxPlacement = {
@@ -20879,8 +20043,7 @@ RP.PropEmotes = {
             11.7427793,
             32.5772863
         },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         PtfxAsset = "scr_tn_meet",
         PtfxName = "scr_tn_meet_phone_camera_flash",
         PtfxPlacement = {
@@ -20921,8 +20084,7 @@ RP.PropEmotes = {
             3.10072,
             -8.4531301
         },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         ExitEmote = "getup",
         ExitEmoteType = "Exits",
         PtfxAsset = "scr_tn_meet",
@@ -20965,8 +20127,7 @@ RP.PropEmotes = {
             66.9464998,
             -62.7303262
         },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         PtfxAsset = "scr_tn_meet",
         PtfxName = "scr_tn_meet_phone_camera_flash",
         PtfxPlacement = {
@@ -21007,8 +20168,7 @@ RP.PropEmotes = {
             -0.6965831,
             -4.2803096
        },
-        EmoteLoop = true,
-        EmoteMoving = false,
+        onFootFlag = AnimFlag.LOOP,
         PtfxAsset = "scr_tn_meet",
         PtfxName = "scr_tn_meet_phone_camera_flash",
         PtfxPlacement = {
@@ -21039,8 +20199,7 @@ RP.PropEmotes = {
                 -109.544,
                 18.717
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf"] = { -- Emote by WhiskerValeMods
@@ -21058,8 +20217,7 @@ RP.PropEmotes = {
                 -180.0000,
                 -40.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf2"] = { -- Custom Emote by WhiskerValeMods
@@ -21076,8 +20234,7 @@ RP.PropEmotes = {
                 0.0,
                 -170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf3"] = { -- Custom Emote by WhiskerValeMods
@@ -21094,8 +20251,7 @@ RP.PropEmotes = {
                 0.0,
                 -170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf4"] = { -- Custom Emote by WhiskerValeMods
@@ -21112,8 +20268,7 @@ RP.PropEmotes = {
                 0.0,
                 -170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf5"] = { -- Custom Emote By WhiskerValeMods
@@ -21130,8 +20285,7 @@ RP.PropEmotes = {
                 0.0,
                 -170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf6"] = { -- Custom Emote By WhiskerValeMods
@@ -21159,8 +20313,7 @@ RP.PropEmotes = {
                 -180.0000,
                 9.0999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf7"] = { -- Custom Emote By Emote by WhiskerValeMods
@@ -21188,8 +20341,7 @@ RP.PropEmotes = {
                 -180.0000,
                 10.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["sitchairf8"] = { -- Custom Emote By Emote by WhiskerValeMods
@@ -21217,8 +20369,7 @@ RP.PropEmotes = {
                 -180.0000,
                 10.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["dig"] = {
@@ -21247,8 +20398,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ['axe'] = {
@@ -21266,8 +20416,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["axe2"] = {
@@ -21285,8 +20434,7 @@ RP.PropEmotes = {
               165.0749,
                13.9114,
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ['axe3'] = {
@@ -21304,8 +20452,7 @@ RP.PropEmotes = {
               163.6144,
                20.6091
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["axe4"] = {
@@ -21323,8 +20470,7 @@ RP.PropEmotes = {
                 -20.0,
                 175.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["bongos"] = {
@@ -21342,8 +20488,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["medbag"] = {
@@ -21361,8 +20506,7 @@ RP.PropEmotes = {
                 -180.00,
                 -78.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
      },
     ["medbox"] = {
@@ -21380,8 +20524,7 @@ RP.PropEmotes = {
                 0.0000,
               -81.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["dufbag"] = {
@@ -21399,8 +20542,7 @@ RP.PropEmotes = {
                 0.00,
                 -78.99
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shopbag"] = {
@@ -21418,8 +20560,7 @@ RP.PropEmotes = {
                 -90.00,
                 10.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shopbag2"] = {
@@ -21437,8 +20578,7 @@ RP.PropEmotes = {
                 91.19,
                 9.97
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shopbag3"] = {
@@ -21456,8 +20596,7 @@ RP.PropEmotes = {
                 -90.00,
                 10.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['shopbag4'] = {
@@ -21508,8 +20647,7 @@ RP.PropEmotes = {
             },
             PtfxInfo = Translate('camera'),
             PtfxWait = 200,
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["summon"] = {
@@ -21527,8 +20665,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["summon2"] = {
@@ -21546,8 +20683,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["handbag"] = { -- Custom prop by crowded1337
@@ -21565,8 +20701,7 @@ RP.PropEmotes = {
                 -177.4267,
                 83.0011
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["idcard"] = {
@@ -21584,9 +20719,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardb"] = {
@@ -21604,9 +20738,8 @@ RP.PropEmotes = {
              -180.00,
                78.999
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardc"] = {
@@ -21624,9 +20757,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardd"] = {
@@ -21644,9 +20776,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcarde"] = {
@@ -21664,9 +20795,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardf"] = {
@@ -21684,9 +20814,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardg"] = {
@@ -21704,9 +20833,8 @@ RP.PropEmotes = {
               -88.0171,
                63.0612
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["idcardh"] = {
@@ -21724,9 +20852,8 @@ RP.PropEmotes = {
              -176.6694,
                74.9000
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["idcardi"] = {
@@ -21744,9 +20871,8 @@ RP.PropEmotes = {
               -177.8499,
                 23.6377
             },
-            EmoteStuck = true,
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootflag = AnimFlag.STUCK,
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["phone"] = {
@@ -21774,8 +20900,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sms"] = {
@@ -21803,8 +20928,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "phoneaway",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -21847,8 +20971,7 @@ RP.PropEmotes = {
                 00.00,
                 00.00
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "phoneaway",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -21891,8 +21014,7 @@ RP.PropEmotes = {
                 -72.07,
                 6.39
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "phoneaway",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -21935,8 +21057,7 @@ RP.PropEmotes = {
                 -78.50,
                 14.97
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "phoneaway",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -21979,8 +21100,7 @@ RP.PropEmotes = {
                 88.845,
                 29.979
             },
-            EmoteLoop = false,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             ExitEmote = "phoneaway",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -22023,8 +21143,7 @@ RP.PropEmotes = {
                 -4.6998,
                  1.7081
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
             ExitEmoteType = "Exits",
             PtfxAsset = "scr_tn_meet",
@@ -22057,8 +21176,7 @@ RP.PropEmotes = {
                 -55.0,
                 150.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["golfswing"] = {
@@ -22066,7 +21184,7 @@ RP.PropEmotes = {
         "swing_a_mark",
         "Golf Swing",
         AnimationOptions = {
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Prop = "prop_golf_wood_01",
             PropBone = 28422,
             PropPlacement = {
@@ -22094,8 +21212,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weedbrick"] = {
@@ -22113,8 +21230,7 @@ RP.PropEmotes = {
                 -90.0,
                 90.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weedbrick2"] = {
@@ -22132,8 +21248,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["potplant"] = {
@@ -22151,8 +21266,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["potplant2"] = {
@@ -22170,8 +21284,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["potplant3"] = {
@@ -22189,8 +21302,7 @@ RP.PropEmotes = {
                 290.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["weedbucket"] = {
@@ -22208,8 +21320,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["lawnchair"] = {
@@ -22227,8 +21338,7 @@ RP.PropEmotes = {
                 -5.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["lawnchair2"] = {
@@ -22246,8 +21356,7 @@ RP.PropEmotes = {
                 5.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["lawnchair3"] = {
@@ -22265,8 +21374,7 @@ RP.PropEmotes = {
                 0.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["rose2"] = {
@@ -22284,8 +21392,7 @@ RP.PropEmotes = {
                 4.564,
                 39.910
             },
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["rose3"] = {
@@ -22303,8 +21410,7 @@ RP.PropEmotes = {
                 0.00,
                 2.99
             },
-            EmoteLoop = false,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING
         }
     },
     ["cbbox"] = {
@@ -22322,8 +21428,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cbbox2"] = {
@@ -22341,8 +21446,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cbbox3"] = {
@@ -22360,8 +21464,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cbbox4"] = {
@@ -22379,8 +21482,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cbbox5"] = {
@@ -22398,8 +21500,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cbbox6"] = {
@@ -22417,8 +21518,7 @@ RP.PropEmotes = {
                 -180.00,
                 1.99
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbin"] = {
@@ -22436,8 +21536,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbin2"] = {
@@ -22455,8 +21554,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbin3"] = {
@@ -22474,8 +21572,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbin4"] = {
@@ -22493,8 +21590,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["gbin5"] = {
@@ -22512,8 +21608,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag'] = {
@@ -22531,8 +21626,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag2'] = {
@@ -22550,8 +21644,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag3'] = {
@@ -22569,8 +21662,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag4'] = {
@@ -22588,8 +21680,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag5'] = {
@@ -22607,8 +21698,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag6'] = {
@@ -22626,8 +21716,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag7'] = {
@@ -22645,8 +21734,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag8'] = {
@@ -22664,8 +21752,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['pflag9'] = {
@@ -22683,8 +21770,7 @@ RP.PropEmotes = {
                 -141.2988,
                 12.3308
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['old'] = {
@@ -22735,8 +21821,7 @@ RP.PropEmotes = {
             },
             PtfxInfo = Translate('camera'),
             PtfxWait = 200,
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['old2'] = { -- Custom Animation By Darks Animations
@@ -22754,8 +21839,7 @@ RP.PropEmotes = {
                85.0955,
                23.1787,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['lighter'] = {
@@ -22783,8 +21867,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -22827,8 +21910,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -22863,8 +21945,7 @@ RP.PropEmotes = {
                 188.0,
                 10.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['digiscan'] = {
@@ -22882,8 +21963,7 @@ RP.PropEmotes = {
                 2.5616,
                 -15.7909
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['digiscan2'] = {
@@ -22901,8 +21981,7 @@ RP.PropEmotes = {
                 2.5616,
                 -15.7909
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['digiscan3'] = {
@@ -22920,8 +21999,7 @@ RP.PropEmotes = {
                 2.5616,
                 -15.7909
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cop4"] = {
@@ -22939,8 +22017,7 @@ RP.PropEmotes = {
                 -20.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["copbeacon"] = { -- Added for compatibility
@@ -22958,8 +22035,7 @@ RP.PropEmotes = {
                 -20.0,
                 180.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["leanphone"] = {
@@ -22967,8 +22043,7 @@ RP.PropEmotes = {
         "base",
         "Leaning With Phone",
         AnimationOptions = {
-            EmoteMoving = false,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             Prop = "prop_phone_ing",
             PropTextureVariations = {
                 {Name = "<font color=\"#00A0F4\">Blue", Value = 0},
@@ -23006,8 +22081,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteMoving = false,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         },
         AdultAnimation = true
     },
@@ -23026,8 +22100,7 @@ RP.PropEmotes = {
                 240.0,
                 -60.0
             },
-            EmoteMoving = true,
-            EmoteLoop = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["surfboard"] = { -- Emote by Molly
@@ -23046,8 +22119,7 @@ RP.PropEmotes = {
                 176.1446,
                 -2.1500
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stealtv"] = { -- Emote by Molly
@@ -23066,8 +22138,7 @@ RP.PropEmotes = {
                 168.9069,
                 84.2402
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["beachring"] = { -- Emote by Molly
@@ -23086,8 +22157,7 @@ RP.PropEmotes = {
                 0.0,
                 -2.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cashcase"] = {
@@ -23105,8 +22175,7 @@ RP.PropEmotes = {
                 0.0,
                 -90.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cashcase2"] = {
@@ -23124,8 +22193,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cashcase3"] = {
@@ -23143,8 +22211,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cashcase4"] = {
@@ -23162,8 +22229,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["airportbag"] = {
@@ -23181,8 +22247,7 @@ RP.PropEmotes = {
                 0.0,
                 30.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["airportbag2"] = { -- Custom Emote By Dark Animations exclusive to RPEmotes
@@ -23220,8 +22285,7 @@ RP.PropEmotes = {
              -150.5805,
                46.7080
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_tn_meet",
             PtfxName = "scr_tn_meet_phone_camera_flash",
             PtfxPlacement = {
@@ -23252,7 +22316,7 @@ RP.PropEmotes = {
                -6.1917,
               -24.3334
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["megaphone"] = { -- Custom Emote By MollyEmotes
@@ -23270,8 +22334,7 @@ RP.PropEmotes = {
                 -13.0889,
                 -16.0242
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["megaphone2"] = { -- Custom Emote By MollyEmotes
@@ -23289,8 +22352,7 @@ RP.PropEmotes = {
                 -13.0889,
                 -16.0242
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["megaphone3"] = {
@@ -23308,8 +22370,7 @@ RP.PropEmotes = {
                -2.3093,
               -10.9030
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["easter"] = {
@@ -23337,8 +22398,7 @@ RP.PropEmotes = {
                 0.0,
                0.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["easter2"] = {
@@ -23356,8 +22416,7 @@ RP.PropEmotes = {
                 0.4622,
                 10.8906
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bball"] = { -- Custom Emote By Struggleville
@@ -23375,8 +22434,7 @@ RP.PropEmotes = {
                 0.0,
                 40.00
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bball2"] = { -- Custom Emote By Struggleville
@@ -23394,8 +22452,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bball3"] = { -- Custom Emote By Struggleville
@@ -23413,8 +22470,7 @@ RP.PropEmotes = {
                -99.9999,
                 79.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bball4"] = { -- Custom Emote By SapphireMods
@@ -23432,7 +22488,7 @@ RP.PropEmotes = {
                -99.9999,
                 79.9999
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["bball5"] = {
@@ -23450,8 +22506,7 @@ RP.PropEmotes = {
                -99.9999,
                 79.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["ftorch"] = {
@@ -23469,8 +22524,7 @@ RP.PropEmotes = {
                 -1.0,
                 -10.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['ftorch2'] = {
@@ -23488,8 +22542,7 @@ RP.PropEmotes = {
                 0.0000,
                 0.0000,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ['candle'] = {
@@ -23507,8 +22560,7 @@ RP.PropEmotes = {
                10.0000,
                 0.0000,
             },
-            EmoteMoving = true,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "core",
             PtfxName = "ent_amb_candle_flame",
             PtfxNoProp = true,
@@ -23541,8 +22593,7 @@ RP.PropEmotes = {
                 81.7098,
                 -39.2734
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         },
         AdultAnimation = true
     },
@@ -23561,8 +22612,7 @@ RP.PropEmotes = {
                 0.0,
                 -12.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         },
     },
     ["gamer"] = { -- Custom Emote By MissSnowie
@@ -23580,7 +22630,7 @@ RP.PropEmotes = {
               -62.9570,
                17.5872
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -23599,7 +22649,7 @@ RP.PropEmotes = {
               -72.9699,
                 0.0000
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -23618,7 +22668,7 @@ RP.PropEmotes = {
              -145.7418,
               -79.5760,
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -23647,8 +22697,7 @@ RP.PropEmotes = {
                 178.6009,
                 29.9195
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["propose"] = { -- Custom Emote By ultrahacx
@@ -23666,7 +22715,7 @@ RP.PropEmotes = {
                 4.4141,
                -79.3552
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["propose2"] = { -- Custom Emote By ultrahacx
@@ -23684,7 +22733,7 @@ RP.PropEmotes = {
                 88.4373,
                 -9.8783
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["propose3"] = { -- Custom Emote By ultrahacx
@@ -23702,7 +22751,7 @@ RP.PropEmotes = {
                 88.4373,
                 -9.8783
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["holdfw"] = {
@@ -23721,8 +22770,7 @@ RP.PropEmotes = {
                -2.5736,
                -3.0631
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_indep_fireworks",
             PtfxName = "scr_indep_firework_trail_spawn",
             PtfxPlacement = {
@@ -23753,7 +22801,7 @@ RP.PropEmotes = {
                2.9283,
               -12.5092
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
             ExitEmote = "getup",
         }
     },
@@ -23772,8 +22820,7 @@ RP.PropEmotes = {
                0.0,
                80.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["patrolf2"] = {
@@ -23791,8 +22838,7 @@ RP.PropEmotes = {
                0.0,
                80.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["patrolf3"] = {
@@ -23810,8 +22856,7 @@ RP.PropEmotes = {
                0.0,
                80.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["patrolf4"] = { -- Huge thanks to MadsLeander on GitHub
@@ -23839,8 +22884,7 @@ RP.PropEmotes = {
               164.6747,
                -7.5569
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["patrolcar"] = {
@@ -23858,7 +22902,7 @@ RP.PropEmotes = {
                0.0,
              100.0000
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["pineapple"] = { -- Custom Prop by hollywoodiownu
@@ -23876,8 +22920,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         },
     },
     ["present"] = {
@@ -23895,8 +22938,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["patrolcarl"] = {
@@ -23914,7 +22956,7 @@ RP.PropEmotes = {
                0.0,
              100.0000
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["patrolcarr"] = {
@@ -23932,7 +22974,7 @@ RP.PropEmotes = {
                0.0,
              100.0000
             },
-            EmoteLoop = true
+            onFootFlag = AnimFlag.LOOP
         }
     },
     ["papers"] = {
@@ -23950,8 +22992,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vlog"] = {
@@ -23969,8 +23010,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["vlog2"] = {
@@ -23988,8 +23028,7 @@ RP.PropEmotes = {
              110.0,
              -11.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatesit"] = { -- Custom Emote By CMG Mods
@@ -24007,7 +23046,7 @@ RP.PropEmotes = {
                0.0,
                0.0
             },
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["skatesit2"] = { -- Custom Emote By Chocoholic Animations
@@ -24025,8 +23064,7 @@ RP.PropEmotes = {
                0.0,
                0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["skatekneel"] = { -- Custom Emote By DRX Animations
@@ -24044,8 +23082,7 @@ RP.PropEmotes = {
                 4.4024,
               -16.913
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
      },
     ["skatekneel2"] = { -- Custom Emote By DRX Animations
@@ -24063,8 +23100,7 @@ RP.PropEmotes = {
                 4.4024,
               -16.913
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["skatehold"] = {
@@ -24092,8 +23128,7 @@ RP.PropEmotes = {
                -112.2983,
                 -86.1199
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatehold2"] = { -- Emote by Molly
@@ -24111,8 +23146,7 @@ RP.PropEmotes = {
                175.3526,
                49.7964
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatehold3"] = { -- Custom Emote By Chocoholic Animations
@@ -24130,8 +23164,7 @@ RP.PropEmotes = {
                 28.0000,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["skatehold4"] = {
@@ -24159,8 +23192,7 @@ RP.PropEmotes = {
                -112.2983,
                 -86.1199
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatehold5"] = { -- Emote by Molly
@@ -24178,8 +23210,7 @@ RP.PropEmotes = {
                175.3526,
                49.7964
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatehold6"] = { -- Custom Emote By Chocoholic Animations
@@ -24197,8 +23228,7 @@ RP.PropEmotes = {
                 28.0000,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["skatehold7"] = { -- Custom Emote By DRX Animations
@@ -24216,8 +23246,7 @@ RP.PropEmotes = {
               -13.1506,
               -33.6511
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["skatehold8"] = { -- Custom Emote By DRX Animations
@@ -24235,8 +23264,7 @@ RP.PropEmotes = {
               -13.1506,
               -33.6511
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["mafia"] = { -- Custom Emote By Chocoholic Animations
@@ -24264,8 +23292,7 @@ RP.PropEmotes = {
                 0.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
             PtfxAsset = "scr_mp_cig",
             PtfxName = "ent_anim_cig_smoke",
             PtfxNoProp = false,
@@ -24298,8 +23325,7 @@ RP.PropEmotes = {
                 108.17,
                 -17.48
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["shield2"] = {
@@ -24317,8 +23343,7 @@ RP.PropEmotes = {
                 105.38,
                 -10.14
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["cofpose"] = {
@@ -24346,8 +23371,7 @@ RP.PropEmotes = {
                 8.0371,
               17.0945
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
 	["holster6"] = {
@@ -24365,8 +23389,7 @@ RP.PropEmotes = {
                -8.6822,
                 4.9809
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["holster8"] = {
@@ -24384,8 +23407,7 @@ RP.PropEmotes = {
                0.0000,
                3.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["heartprop"] = {
@@ -24403,8 +23425,7 @@ RP.PropEmotes = {
                0.0000,
               -0.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["popcorn"] = {
@@ -24422,8 +23443,7 @@ RP.PropEmotes = {
               176.9331,
                11.9833
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["sax"] = {
@@ -24441,8 +23461,7 @@ RP.PropEmotes = {
               29.3364,
                5.9514
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["poolcue"] = {
@@ -24460,8 +23479,7 @@ RP.PropEmotes = {
               -7.2194,
                3.1642
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["poolcue2"] = {
@@ -24479,8 +23497,7 @@ RP.PropEmotes = {
               -1.4526,
                1.8479
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["poolcue3"] = {
@@ -24498,8 +23515,7 @@ RP.PropEmotes = {
                0.0,
                0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["poolcue4"] = {
@@ -24517,8 +23533,7 @@ RP.PropEmotes = {
               14.4214,
              -13.2854
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["poolcue5"] = {
@@ -24536,8 +23551,7 @@ RP.PropEmotes = {
               -9.5838,
                2.9748,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["basket"] = {
@@ -24555,8 +23569,7 @@ RP.PropEmotes = {
               115.0,
                19.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["basket2"] = {
@@ -24574,8 +23587,7 @@ RP.PropEmotes = {
               115.0,
                19.0,
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["power"] = {
@@ -24593,8 +23605,7 @@ RP.PropEmotes = {
                12.0,
                -99.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["wlight"] = {
@@ -24612,8 +23623,7 @@ RP.PropEmotes = {
                 0.0,
               -90.0
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["businessbag"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24631,8 +23641,7 @@ RP.PropEmotes = {
              -54.1834,
              -88.4424
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
    },
    ["businessbag2"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24650,8 +23659,7 @@ RP.PropEmotes = {
              -54.1834,
              -88.4424
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["squatcash"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24669,8 +23677,7 @@ RP.PropEmotes = {
             -164.7312,
               25.2203
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["squatmask"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24688,8 +23695,7 @@ RP.PropEmotes = {
                0.0000,
                0.0000,
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["squatmask1"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24707,8 +23713,7 @@ RP.PropEmotes = {
                0.0000,
                0.0000,
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["squatmask2"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24726,8 +23731,7 @@ RP.PropEmotes = {
                0.0000,
                0.0000,
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["selfiesquat"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Mr Witt
@@ -24778,7 +23782,7 @@ RP.PropEmotes = {
             },
             PtfxInfo = Translate('camera'),
             PtfxWait = 200,
-            EmoteLoop = true,
+            onFootFlag = AnimFlag.LOOP,
         }
    },
    ["femscaremask"] = { -- Animation by MrWitt
@@ -24796,8 +23800,7 @@ RP.PropEmotes = {
                 -81.9467213,
                 9.0687101
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
             }
    },
    ["femscaremask2"] = { -- Animation by MrWitt
@@ -24815,8 +23818,7 @@ RP.PropEmotes = {
         -81.9467213,
         9.0687101
         },
-        EmoteLoop = true,
-        EmoteMoving = true
+        onFootFlag = AnimFlag.MOVING,
         }
    },
    ["femscaremask3"] = { -- Animation by MrWitt
@@ -24834,8 +23836,7 @@ RP.PropEmotes = {
         -81.9467213,
         9.0687101
         },
-        EmoteLoop = true,
-        EmoteMoving = true
+        onFootFlag = AnimFlag.MOVING,
         },
    },
    ["raiseglass"] = { -- Custom Animation by Chocoholic Animations
@@ -24853,8 +23854,7 @@ RP.PropEmotes = {
         0.0000,
         0.0000
         },
-        EmoteLoop = true,
-        EmoteMoving = true
+        onFootFlag = AnimFlag.MOVING,
         },
     },
     ["raiseglass2"] = { -- Custom Animation by Chocoholic Animations
@@ -24872,8 +23872,7 @@ RP.PropEmotes = {
         0.0000,
        -2.9999
         },
-        EmoteLoop = true,
-        EmoteMoving = true
+        onFootFlag = AnimFlag.MOVING,
         },
     },
     ["squatgunpose2"] = { -- Custom Emote By Darks Animations
@@ -24891,7 +23890,7 @@ RP.PropEmotes = {
        -6.9836,
         23.6186
         },
-        EmoteLoop = true,
+        onFootFlag = AnimFlag.LOOP,
         },
     },
     ["rap2"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -24909,8 +23908,7 @@ RP.PropEmotes = {
                0.0000,
              170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["rap3"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -24928,8 +23926,7 @@ RP.PropEmotes = {
                0.0000,
              170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["rap4"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -24947,8 +23944,7 @@ RP.PropEmotes = {
                0.0000,
              170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["rap5"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -24966,8 +23962,7 @@ RP.PropEmotes = {
                0.0000,
              170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
 			ExitEmote = "getup",
         }
     },
@@ -24986,8 +23981,7 @@ RP.PropEmotes = {
                0.0000,
              170.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["bbat"] = { -- Custom Emote Provided To RPEmotes Courtesy Of Darks Animations
@@ -25005,8 +23999,7 @@ RP.PropEmotes = {
                0.8479,
              -12.8826
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["stopsign"] = { -- Custom Prop By PNWParksFan
@@ -25024,8 +24017,7 @@ RP.PropEmotes = {
                0.0000,
              -50.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stopsign2"] = { -- Custom Prop By PNWParksFan
@@ -25043,8 +24035,7 @@ RP.PropEmotes = {
                0.0000,
              120.0000
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stopsign3"] = { -- Custom Prop By PNWParksFan
@@ -25062,8 +24053,7 @@ RP.PropEmotes = {
             -180.0000,
               59.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stopsign4"] = { -- Custom Prop By PNWParksFan
@@ -25081,8 +24071,7 @@ RP.PropEmotes = {
                 0.0000,
                 -59.9999
             },
-            EmoteLoop = true,
-            EmoteMoving = true,
+            onFootFlag = AnimFlag.MOVING,
         }
     },
     ["stonerbabepose"] = { -- Custom Emote provided by 41anims
@@ -25100,8 +24089,7 @@ RP.PropEmotes = {
                 170.0,
                 0.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["baddiegyat"] = { -- Custom Emote provided by 41anims
@@ -25129,8 +24117,7 @@ RP.PropEmotes = {
                 3.367247,
                 0.0711684
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["murder1"] = {
@@ -25158,8 +24145,7 @@ RP.PropEmotes = {
                 -51.0,
                 237.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["murder2"] = {
@@ -25187,8 +24173,7 @@ RP.PropEmotes = {
                 -7.0,
                 237.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
     ["murder3"] = {
@@ -25216,8 +24201,7 @@ RP.PropEmotes = {
                 182.3,
                 -10.0
             },
-            EmoteLoop = true,
-            EmoteMoving = false,
+            onFootFlag = AnimFlag.LOOP,
         }
     },
 }

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -552,14 +552,8 @@ function OnEmotePlay(name, textureVariation)
         else
             movementType = 51
         end
-    elseif animOption then
-        if animOption.EmoteMoving then
-            movementType = 51
-        elseif animOption.EmoteLoop then
-            movementType = 1
-        elseif animOption.EmoteStuck then
-            movementType = 50
-        end
+    elseif animOption and animOption.onFootFlag then
+        movementType = animOption.onFootFlag
     end
 
     DebugPrint("Animation flag = (" .. movementType .. ")")
@@ -690,23 +684,13 @@ function OnEmotePlayClone(name)
         return
     end
 
-    local movementType = 0
-
-    if animOption then
-        if animOption.EmoteMoving then
-            movementType = 51
-        elseif animOption.EmoteLoop then
-            movementType = 1
-        elseif animOption.EmoteStuck then
-            movementType = 50
-        end
-    end
+    local flag = animOption?.Flag or animOption?.onFootFlag or 0
 
     if IsPedUsingAnyScenario(ClonedPed) or IsPedActiveInScenario(ClonedPed) then
         ClearPedTasksImmediately(ClonedPed)
     end
 
-    TaskPlayAnim(ClonedPed, emoteData.dict, emoteData.anim, 5.0, 5.0, animOption and animOption.EmoteDuration or -1, animOption?.Flag or movementType, 0, false, false, false)
+    TaskPlayAnim(ClonedPed, emoteData.dict, emoteData.anim, 5.0, 5.0, animOption and animOption.EmoteDuration or -1, flag, 0, false, false, false)
     RemoveAnimDict(emoteData.dict)
 
     if animOption and animOption.Prop then

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -449,6 +449,7 @@ function OpenEmoteMenu()
     end
 end
 
+---@param emote EmoteData
 local function convertToEmoteData(emote)
     local arraySize = 0
     for i = 1, 4 do
@@ -474,6 +475,17 @@ local function convertToEmoteData(emote)
         end
 
         emote.label = emote[3]
+    end
+
+    local animOptions = emote.AnimationOptions
+    if animOptions and not animOptions.onFootFlag then
+        if animOptions.EmoteMoving then
+            animOptions.onFootFlag = AnimFlag.MOVING
+        elseif animOptions.EmoteLoop then
+            animOptions.onFootFlag = AnimFlag.LOOP
+        elseif animOptions.EmoteStuck then
+            animOptions.onFootFlag = AnimFlag.STUCK
+        end
     end
 end
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -33,6 +33,7 @@ server_scripts {
 }
 
 client_scripts {
+    'types.lua',
     'NativeUI.lua',
     'client/Utils.lua',
     'client/Bridge.lua',

--- a/types.lua
+++ b/types.lua
@@ -1,4 +1,9 @@
----@meta
+---@enum AnimFlag
+AnimFlag = {
+    MOVING = 51,
+    LOOP = 1,
+    STUCK = 50,
+}
 
 ---@alias Dictionary string
 ---@alias AnimName string
@@ -13,9 +18,11 @@
 ---@field A number
 
 ---@class AnimationOptions
----@field EmoteMoving? boolean
----@field EmoteLoop? boolean
----@field EmoteStuck? boolean
+---@field EmoteMoving? boolean deprecated. Set onFootFlag instead
+---@field EmoteLoop? boolean deprecated. Set onFootFlag instead
+---@field EmoteStuck? boolean deprecated. Set onFootFlag instead
+---@field onFootFlag? AnimFlag anim flag to use when not in a vehicle
+---@field Flag? integer anim flag to use. If set, overrides onFootFlag.
 ---@field FullBody? boolean
 ---@field Attachto? boolean
 ---@field NotInVehicle? boolean
@@ -54,7 +61,6 @@
 ---@field ExitEmoteType? "Exits" deprecated. unused.
 ---@field BlendInSpeed? number
 ---@field BlendOutSpeed? number
----@field Flag? integer
 
 ---@class AnimationListConfig
 ---@field Expressions table<string, {[1]: AnimName, [2]: Label?}>


### PR DESCRIPTION
Looking at the code, we can observe that the current AnimationOptions EmoteMoving, EmoteLoop, and EmoteStuck are mutually exclusive booleans. A set of mutually exclusive options is a good smell that an enum would be more appropriate to represent the selection of these options.

It is a bit weird that these are mutually exclusive as the naming suggests that they should be individual bits of the native animation flag. However, since this code is 3 years old, changing these to be additive instead of mutually exclusive would be a breaking change.

Naming the enum onFootFlag as the logic for playing an emote bypasses these options entirely when the player is in a vehicle. In this PR I introduced the new enum option, deprecated the old boolean options, and updated the callsites and references. The boolean options will still work and are converted to the enum within the conversion code from config to EmoteData.