### PR TITLE
refactor: convert ScenarioType and Category to enums

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -5167,200 +5167,200 @@ RP.Emotes = {
     ------ THESE ARE SCENARIOS, SOME OF THESE DON'T WORK ON WOMEN AND SOME OTHER ISSUES, BUT STILL GOOD TO HAVE    ------
     -----------------------------------------------------------------------------------------------------------
     ["atm"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "PROP_HUMAN_ATM",
         "ATM"
     },
     ["bbq"] = {
-        "MaleScenario",
+        ScenarioType.MALE,
         "PROP_HUMAN_BBQ",
         "BBQ"
     },
     ["bumbin"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "PROP_HUMAN_BUM_BIN",
         "Bum Bin"
     },
     ["cheer"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_CHEERING",
         "Cheer"
     },
     ["chinup"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "PROP_HUMAN_MUSCLE_CHIN_UPS",
         "Chinup"
     },
     ["clipboard2"] = {
-        "MaleScenario",
+        ScenarioType.MALE,
         "WORLD_HUMAN_CLIPBOARD",
         "Clipboard 2"
     },
     ["cop"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_COP_IDLES",
         "Cop"
     },
     ["drill"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_CONST_DRILL",
         "Construction Drilling"
     },
     ["filmshocking"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_MOBILE_FILM_SHOCKING",
         "Film Shocking"
     },
     ["flex"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_MUSCLE_FLEX",
         "Flex"
     },
      ["guard"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_GUARD_STAND",
         "Guard"
     },
     ["garden"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_GARDENER_PLANT",
         "Gardening"
     },
     ["hammer"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_HAMMERING",
         "Hammer"
     },
     ["hangout"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_HANG_OUT_STREET",
         "Hangout"
     },
     ["impatient"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_STAND_IMPATIENT",
         "Impatient"
     },
     ["janitor"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_JANITOR",
         "Janitor"
     },
     ["jog"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_JOG_STANDING",
         "Jog"
     },
     ["kneel"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "CODE_HUMAN_MEDIC_KNEEL",
         "Kneel"
     },
     ["lean"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_LEANING",
         "Lean"
     },
     ["leanbar"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "PROP_HUMAN_BUM_SHOPPING_CART",
         "Lean Bar"
     },
     ["lookout"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "CODE_HUMAN_CROSS_ROAD_WAIT",
         "Lookout"
     },
     ["maid"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_MAID_CLEAN",
         "Maid"
     },
     ["medic"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "CODE_HUMAN_MEDIC_TEND_TO_DEAD",
         "Medic"
     },
     ["musician"] = {
-        "MaleScenario",
+        ScenarioType.MALE,
         "WORLD_HUMAN_MUSICIAN",
         "Musician"
     },
     -- Ambient Music Doesn't Seem To Work For Female, Hence It's Male Only
     ["notepad2"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "CODE_HUMAN_MEDIC_TIME_OF_DEATH",
         "Notepad 2"
     },
     ["parkingmeter"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "PROP_HUMAN_PARKING_METER",
         "Parking Meter"
     },
     ["party"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_PARTYING",
         "Party"
     },
     ["texting"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_STAND_MOBILE",
         "Texting"
     },
     ["prosthigh"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_PROSTITUTE_HIGH_CLASS",
         "Prostitue High"
     },
     ["prostlow"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_PROSTITUTE_LOW_CLASS",
         "Prostitue Low"
     },
     ["puddle"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_BUM_WASH",
         "Puddle"
     },
     ["record"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_MOBILE_FILM_SHOCKING",
         "Record"
     },
     ["smoke"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_SMOKING",
         "Smoke"
     },
     ["smokeweed"] = {
-        "MaleScenario",
+        ScenarioType.MALE,
         "WORLD_HUMAN_DRUG_DEALER",
         "Smoke Weed (Male)"
     },
     -- Female
     ["smokeweed2"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_SMOKING_POT",
         "Smoke Weed (Female)"
     },
     -- Female
     ["statue"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_HUMAN_STATUE",
         "Statue"
     },
     ["weld"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_WELDING",
         "Weld"
     },
     ["windowshop"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_WINDOW_SHOP_BROWSE",
         "Window Shop"
     },
     ["yoga"] = {
-        "Scenario",
+        ScenarioType.SCENARIO,
         "WORLD_HUMAN_YOGA",
         "Yoga"
     },

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -19,7 +19,7 @@ local function ResetCrouch()
     local walkstyle = GetResourceKvpString("walkstyle")
     if walkstyle then
         local toApply = EmoteData[walkstyle]
-        if not toApply or type(toApply) ~= "table" or toApply.category ~= "Walks" then
+        if not toApply or type(toApply) ~= "table" or toApply.category ~= Category.WALKS then
             ResetPedMovementClipset(playerPed, 0.5)
             DeleteResourceKvp("walkstyle")
             DebugPrint('Invalid walkstyle found in KVP, resetting to default.')

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -5,6 +5,7 @@ CurrentTextureVariation = nil
 InHandsup = false
 CONVERTED = false
 
+---@type ScenarioType
 local ChosenScenarioType
 local CurrentAnimOptions
 local PlayerGender = "male"
@@ -160,7 +161,7 @@ function EmoteCancel(force)
 
     if not CanCancel and not force then return end
 
-    if (ChosenScenarioType == "MaleScenario" or ChosenScenarioType == "Scenario") and IsInAnimation then
+    if (ChosenScenarioType == ScenarioType.MALE or ChosenScenarioType == ScenarioType.SCENARIO) and IsInAnimation then
         ClearPedTasksImmediately(PlayerPedId())
         IsInAnimation = false
         DebugPrint("Forced scenario exit")
@@ -226,12 +227,12 @@ function EmoteMenuStart(name, category, textureVariation)
         return
     end
 
-    if category == "Expressions" then
+    if category == Category.EXPRESSIONS then
         SetPlayerPedExpression(name, true)
         return
     end
 
-    if emote.category == "AnimalEmotes" then
+    if emote.category == Category.ANIMAL_EMOTES then
         CheckAnimalAndOnEmotePlay(name)
         return
     end
@@ -254,7 +255,7 @@ function EmoteMenuStartClone(name, category)
         return
     end
 
-    if category == "Expressions" then
+    if category == Category.EXPRESSIONS then
         SetFacialIdleAnimOverride(ClonedPed, emote[1], true)
         return
     end
@@ -292,7 +293,7 @@ function EmoteCommandStart(args)
 
         local emote = EmoteData[name]
         if emote then
-            if emote.category == "AnimalEmotes" then
+            if emote.category == Category.ANIMAL_EMOTES then
                 if Config.AnimalEmotesEnabled then
                     CheckAnimalAndOnEmotePlay(name)
                 else
@@ -301,7 +302,7 @@ function EmoteCommandStart(args)
                 return
             end
 
-            if emote.category == "PropEmotes" and emote.AnimationOptions.PropTextureVariations then
+            if emote.category == Category.PROP_EMOTES and emote.AnimationOptions.PropTextureVariations then
                 if #args > 1 then
                     local textureVariation = tonumber(args[2])
                     if emote.AnimationOptions.PropTextureVariations[textureVariation] then
@@ -513,7 +514,7 @@ function OnEmotePlay(name, textureVariation)
         CheckGender()
         ClearPedTasks(PlayerPedId())
         DestroyAllProps()
-        if emoteData.scenarioType == "MaleScenario" then
+        if emoteData.scenarioType == ScenarioType.MALE then
             if PlayerGender == "male" then
                 TaskStartScenarioInPlace(PlayerPedId(), emoteData.scenario, 0, true)
                 DebugPrint("Playing scenario = (" .. emoteData.scenario .. ")")
@@ -522,7 +523,7 @@ function OnEmotePlay(name, textureVariation)
                 EmoteChatMessage(Translate('maleonly'))
                 return
             end
-        elseif emoteData.scenarioType == "ScenarioObject" then
+        elseif emoteData.scenarioType == ScenarioType.OBJECT then
             local BehindPlayer = GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, -0.5, -0.5)
             TaskStartScenarioAtPosition(PlayerPedId(), emoteData.scenario, BehindPlayer.x, BehindPlayer.y, BehindPlayer.z, GetEntityHeading(PlayerPedId()), 0, true, false)
             DebugPrint("Playing scenario = (" .. emoteData.scenario .. ")")
@@ -666,14 +667,14 @@ function OnEmotePlayClone(name)
         CheckGender()
         ClearPedTasks(ClonedPed)
         DestroyAllProps(true)
-        if emoteData.scenarioType == "MaleScenario" then
+        if emoteData.scenarioType == ScenarioType.MALE then
             if PlayerGender == "male" then
                 TaskStartScenarioInPlace(ClonedPed, emoteData.scenario, 0, true)
             end
-        elseif emoteData.scenarioType == "ScenarioObject" then
+        elseif emoteData.scenarioType == ScenarioType.OBJECT then
             local BehindPlayer = GetOffsetFromEntityInWorldCoords(ClonedPed, 0.0, -0.5, -0.5)
             TaskStartScenarioAtPosition(ClonedPed, emoteData.scenario, BehindPlayer.x, BehindPlayer.y, BehindPlayer.z, GetEntityHeading(ClonedPed), 0, true, false)
-        elseif emoteData.scenarioType == "Scenario" then
+        elseif emoteData.scenarioType == ScenarioType.SCENARIO then
             TaskStartScenarioInPlace(ClonedPed, emoteData.scenario, 0, true)
         end
         return
@@ -728,11 +729,11 @@ end
 function PlayExitAndEnterEmote(name, textureVariation)
     local ped = PlayerPedId()
     if not CanCancel then return end
-    if ChosenScenarioType == "MaleScenario" and IsInAnimation then
+    if ChosenScenarioType == ScenarioType.MALE and IsInAnimation then
         ClearPedTasksImmediately(ped)
         IsInAnimation = false
         DebugPrint("Forced scenario exit")
-    elseif ChosenScenarioType == "Scenario" and IsInAnimation then
+    elseif ChosenScenarioType == ScenarioType.SCENARIO and IsInAnimation then
         ClearPedTasksImmediately(ped)
         IsInAnimation = false
         DebugPrint("Forced scenario exit")

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -117,18 +117,18 @@ function AddEmoteMenu(menu)
 
     dancemenu.OnIndexChange = function(_, newindex)
         ClearPedTaskPreview()
-        EmoteMenuStartClone(DanceTable[newindex], "Dances")
+        EmoteMenuStartClone(DanceTable[newindex], Category.DANCES)
     end
 
     propmenu.OnIndexChange = function(_, newindex)
         ClearPedTaskPreview()
-        EmoteMenuStartClone(PropTable[newindex], "PropEmotes")
+        EmoteMenuStartClone(PropTable[newindex], Category.PROP_EMOTES)
     end
 
     submenu.OnIndexChange = function(_, newindex)
         if newindex > 5 then
             ClearPedTaskPreview()
-            EmoteMenuStartClone(EmoteTable[newindex], "Emotes")
+            EmoteMenuStartClone(EmoteTable[newindex], Category.EMOTES)
         end
     end
 
@@ -137,12 +137,12 @@ function AddEmoteMenu(menu)
     end
 
     dancemenu.OnItemSelect = function(_, _, index)
-        EmoteMenuStart(DanceTable[index], "Dances")
+        EmoteMenuStart(DanceTable[index], Category.DANCES)
     end
 
     if Config.AnimalEmotesEnabled then
         animalmenu.OnItemSelect = function(_, _, index)
-            EmoteMenuStart(AnimalTable[index], "AnimalEmotes")
+            EmoteMenuStart(AnimalTable[index], Category.ANIMAL_EMOTES)
         end
     end
 
@@ -171,18 +171,18 @@ function AddEmoteMenu(menu)
     end
 
     propmenu.OnItemSelect = function(_, _, index)
-        EmoteMenuStart(PropTable[index], "PropEmotes")
+        EmoteMenuStart(PropTable[index], Category.PROP_EMOTES)
     end
 
    propmenu.OnListSelect = function(_, item, itemIndex, listIndex)
-        EmoteMenuStart(PropTable[itemIndex], "PropEmotes", item:IndexToItem(listIndex).Value)
+        EmoteMenuStart(PropTable[itemIndex], Category.PROP_EMOTES, item:IndexToItem(listIndex).Value)
     end
 
     submenu.OnItemSelect = function(_, _, index)
         if Config.Search and EmoteTable[index] == Translate('searchemotes') then
             EmoteMenuSearch(submenu)
         else
-            EmoteMenuStart(EmoteTable[index], "Emotes")
+            EmoteMenuStart(EmoteTable[index], Category.EMOTES)
         end
     end
 
@@ -196,9 +196,9 @@ end
 
 if Config.Search then
     local ignoredCategories = {
-        ["Walks"] = true,
-        ["Expressions"] = true,
-        ["Shared"] = not Config.SharedEmotesEnabled
+        [Category.WALKS] = true,
+        [Category.EXPRESSIONS] = true,
+        [Category.SHARED] = not Config.SharedEmotesEnabled
     }
 
     function EmoteMenuSearch(lastMenu)
@@ -233,7 +233,7 @@ if Config.Search then
                 table.sort(results, function(a, b) return a.name < b.name end)
                 for k, v in pairs(results) do
                     local desc = ""
-                    if v.table == "Shared" then
+                    if v.table == Category.SHARED then
                         local otheremotename = v.data[4]
                         if otheremotename == nil then
                            desc = "/nearby (~g~" .. v.name .. "~w~)"
@@ -250,7 +250,7 @@ if Config.Search then
                         searchMenu:AddItem(NativeUI.CreateItem(v.data[3], desc))
                     end
 
-                    if v.table == "Dances" and Config.SharedEmotesEnabled then
+                    if v.table == Category.DANCES and Config.SharedEmotesEnabled then
                         sharedDanceMenu:AddItem(NativeUI.CreateItem(v.data[3], ""))
                     end
                 end
@@ -274,7 +274,7 @@ if Config.Search then
 
                     if data == Translate('sharedanceemotes') then return end
 
-                    if data.table == "Shared" then
+                    if data.table == Category.SHARED then
                         local target, distance = GetClosestPlayer()
                         if (distance ~= -1 and distance < 3) then
                             TriggerServerEvent("rpemotes:server:requestEmote", GetPlayerServerId(target), data.name)
@@ -288,7 +288,7 @@ if Config.Search then
                 end
 
                 searchMenu.OnListSelect = function(_, item, itemIndex, listIndex)
-                    EmoteMenuStart(results[itemIndex].name, "PropEmotes", item:IndexToItem(listIndex).Value)
+                    EmoteMenuStart(results[itemIndex].name, Category.PROP_EMOTES, item:IndexToItem(listIndex).Value)
                 end
 
                 if Config.SharedEmotesEnabled then
@@ -396,15 +396,15 @@ function AddFaceMenu(menu)
 
 
     submenu.OnIndexChange = function(_, newindex)
-        EmoteMenuStartClone(FaceTable[newindex], "Expressions")
+        EmoteMenuStartClone(FaceTable[newindex], Category.EXPRESSIONS)
     end
 
     submenu.OnItemSelect = function(_, item, index)
         if item == facereset then
-            DeleteResourceKvp("Expressions")
+            DeleteResourceKvp(Category.EXPRESSIONS)
             ClearFacialIdleAnimOverride(PlayerPedId())
         else
-            EmoteMenuStart(FaceTable[index], "Expressions")
+            EmoteMenuStart(FaceTable[index], Category.EXPRESSIONS)
         end
     end
 
@@ -465,7 +465,7 @@ local function convertToEmoteData(emote)
         emote.label = emote[2]
     elseif arraySize >= 3 then
         local type = emote[1]
-        if type == 'MaleScenario' or type == 'Scenario' or type == 'ScenarioObject' then
+        if type == ScenarioType.MALE or type == ScenarioType.SCENARIO or type == ScenarioType.OBJECT then
             emote.scenario = emote[2]
             emote.scenarioType = type
         else

--- a/client/Expressions.lua
+++ b/client/Expressions.lua
@@ -1,6 +1,6 @@
 function SetPlayerPedExpression(expression, saveToKvp)
     local emote = EmoteData[expression]
-    if emote and emote.category == "Expressions" then
+    if emote and emote.category == Category.EXPRESSIONS then
         SetFacialIdleAnimOverride(PlayerPedId(), emote.anim, 0)
         if Config.PersistentExpression and saveToKvp then SetResourceKvp("expression", emote.anim) end
     else
@@ -13,7 +13,7 @@ if Config.ExpressionsEnabled then
     RegisterCommand('mood', function(_source, args, _raw)
         local expression = FirstToUpper(string.lower(args[1]))
         local emote = EmoteData[expression]
-        if emote and emote.category == "Expressions" then
+        if emote and emote.category == Category.EXPRESSIONS then
             SetPlayerPedExpression(EmoteData[expression].anim, true)
         elseif expression == "Reset" then
             ClearFacialIdleAnimOverride(PlayerPedId())

--- a/client/Syncing.lua
+++ b/client/Syncing.lua
@@ -13,7 +13,7 @@ if Config.SharedEmotesEnabled then
             local target, distance = GetClosestPlayer()
             if (distance ~= -1 and distance < 3) then
                 local emote = EmoteData[emotename]
-                if emote ~= nil and emote.category == "Shared" then
+                if emote ~= nil and emote.category == Category.SHARED then
                     TriggerServerEvent("rpemotes:server:requestEmote", GetPlayerServerId(target), emotename)
                     SimpleNotify(Translate('sentrequestto') ..
                         GetPlayerName(target) .. " ~w~(~g~" .. emote.label .. "~w~)")

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -149,7 +149,7 @@ end
 function NearbysOnCommand(source, args, raw)
     local NearbysCommand = ""
     for a, b in PairsByKeys(EmoteData) do
-        if type(b) == "table" and b.category == "Shared" then
+        if type(b) == "table" and b.category == Category.SHARED then
             NearbysCommand = NearbysCommand .. a .. ", "
         end
     end

--- a/client/Walk.lua
+++ b/client/Walk.lua
@@ -11,7 +11,7 @@ function WalkMenuStart(name, force)
         ResetWalk()
         return
     end
-    if not EmoteData[name] or type(EmoteData[name]) ~= "table" or EmoteData[name].category ~= "Walks" then
+    if not EmoteData[name] or type(EmoteData[name]) ~= "table" or EmoteData[name].category ~= Category.WALKS then
         EmoteChatMessage("'" .. tostring(name) .. "' is not a valid walk")
         return
     end
@@ -36,7 +36,7 @@ end
 function WalksOnCommand()
     local WalksCommand = ""
     for name, data in PairsByKeys(EmoteData) do
-        if type(data) == "table" and data.category == "Walks" then
+        if type(data) == "table" and data.category == Category.WALKS then
             WalksCommand = WalksCommand .. string.lower(name) .. ", "
         end
     end
@@ -70,7 +70,7 @@ if Config.WalkingStylesEnabled and Config.PersistentWalk then
         end
 
         local walkstyle = EmoteData[kvp]
-        return walkstyle and type(walkstyle) == "table" and walkstyle.category == "Walks"
+        return walkstyle and type(walkstyle) == "table" and walkstyle.category == Category.WALKS
     end
 
     local function handleWalkstyle()

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -21,6 +21,7 @@ files {
 data_file 'CONDITIONAL_ANIMS_FILE' 'conditionalanims.meta'
 
 shared_scripts {
+    'types.lua',
     'config.lua',
     'locale.lua',
     'locales/*.lua',
@@ -33,7 +34,6 @@ server_scripts {
 }
 
 client_scripts {
-    'types.lua',
     'NativeUI.lua',
     'client/Utils.lua',
     'client/Bridge.lua',

--- a/server/Server.lua
+++ b/server/Server.lua
@@ -108,7 +108,7 @@ local function ExtractEmoteProps(format)
     if not success then return nil end
 
     if format == 4 then
-        local emoteTypes = { "Shared", "Dances", "AnimalEmotes", "Emotes", "PropEmotes", "Expressions", "Walks" }
+        local emoteTypes = { Category.SHARED, Category.DANCES, Category.ANIMAL_EMOTES, Category.EMOTES, Category.PROP_EMOTES, Category.EXPRESSIONS, Category.WALKS }
         local expressionAndWalkCount = 0
         local otherEmotesCount = 0
 
@@ -117,7 +117,7 @@ local function ExtractEmoteProps(format)
             for _ in pairs(res[emoteType]) do
                 count = count + 1
             end
-            if emoteType == "Expressions" or emoteType == "Walks" then
+            if emoteType == Category.EXPRESSIONS or emoteType == Category.WALKS then
                 expressionAndWalkCount = expressionAndWalkCount + count
             else
                 otherEmotesCount = otherEmotesCount + count

--- a/types.lua
+++ b/types.lua
@@ -5,11 +5,29 @@ AnimFlag = {
     STUCK = 50,
 }
 
+---@enum ScenarioType
+ScenarioType = {
+    MALE = 'MaleScenario',
+    SCENARIO = 'Scenario',
+    OBJECT = 'ScenarioObject',
+}
+
+---@enum Category
+Category = {
+    EXPRESSIONS = 'Expressions',
+    WALKS = 'Walks',
+    SHARED = 'Shared',
+    DANCES = 'Dances',
+    ANIMAL_EMOTES = 'AnimalEmotes',
+    EXITS = 'Exits',
+    EMOTES = 'Emotes',
+    PROP_EMOTES = 'PropEmotes',
+}
+
 ---@alias Dictionary string
 ---@alias AnimName string
 ---@alias ScenarioName string
 ---@alias Label string
----@alias ScenarioType 'MaleScenario' | 'Scenario' | 'ScenarioObject'
 
 ---@class Color
 ---@field R number
@@ -69,7 +87,7 @@ AnimFlag = {
 ---@field Dances table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
 ---@field AnimalEmotes table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions, AdultAnimation?: boolean, AnimalEmote?: boolean}>
 ---@field Exits table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
----@field Emotes table<string, {[1]: Dictionary | 'MaleScenario' | 'Scenario', [2]: AnimName | ScenarioName, [3]: Label, AnimationOptions?: AnimationOptions, AdultAnimation?: boolean}>
+---@field Emotes table<string, {[1]: Dictionary | ScenarioType, [2]: AnimName | ScenarioName, [3]: Label, AnimationOptions?: AnimationOptions, AdultAnimation?: boolean}>
 ---@field PropEmotes table<string, {[1]: Dictionary, [2]: AnimName, [3]: Label, AnimationOptions?: AnimationOptions}>
 
 ---@class EmoteData
@@ -86,4 +104,4 @@ AnimFlag = {
 ---@field AnimationOptions? AnimationOptions
 ---@field AnimalEmote? boolean
 ---@field AdultAnimation? boolean
----@field category 'Expressions' | 'Walks' | 'Shared' | 'Dances' | 'AnimalEmotes' | 'Exits' | 'Emotes' | 'PropEmotes'
+---@field category Category


### PR DESCRIPTION
Replace string literals that come up more than once with enums for type safety and readability.