### PR TITLE
refactor(client/Emote): remove for loop which doesn't have any action

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -746,14 +746,6 @@ function OnEmotePlay(name, textureVariation)
         checkStatusThread(emoteData.dict, emoteData.anim)
     end
 
-    for _, emote in pairs(EmoteData) do
-        for propName, propValue in pairs(emote) do
-            if propValue == emoteData then
-                emoteData[#emoteData+1] = propName
-                break
-            end
-        end
-    end
     currentEmote = emoteData
 
     if animOption and animOption.Prop then


### PR DESCRIPTION
propValue will never equal emoteData as propValue is for the key/value pairs of each table within EmoteData, whereas emoteData represents a table of EmoteData.

I'm not sure what the original intention of this code was @iSentrie if we need to make some changes to recapture that.