### PR TITLE
Syringe animation correct prop fix

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -11109,7 +11109,7 @@ RP.PropEmotes = {
         "ped_a_enter_loop",
         "Syringe",
         AnimationOptions = {
-            Prop = "prop_single_rose",
+            Prop = "prop_syringe_01",
             PropBone = 18905,
             PropPlacement = {
                 0.11,


### PR DESCRIPTION
On August 11 2025, I noticed that the prop for /e syringe was a rose instead of a syringe. This will correct the emote to use the right prop.