### PR TITLE
refactor(client/EmoteMenu): Use EmoteData to initialize menu instead of raw anim list

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -483,10 +483,6 @@ local function convertToEmoteData(emote)
         emote.label = emote[3]
     end
 
-    if not emote.category then
-        emote.category = emote.emoteType
-    end
-
     local animOptions = emote.AnimationOptions
     if animOptions and not animOptions.onFootFlag then
         if animOptions.EmoteMoving then


### PR DESCRIPTION
prefactor for #105

This PR moves the menu initialization after EmoteData conversion and then gets data by iterating over the EmoteData table. With this change, the AnimationList is converted to the EmoteData table for stronger types and the AnimationList format is no longer used internally. Because EmoteData is flatter than AnimationList, we're now iterating over a single table to build out various sub menus, rather than iterate over several sub tables of AnimationList.

Also took the opportunity to change some string concatenation to string.format for better readability and extract a few sub functions from the main thread which was loading adding, converting data, and initializing menus.

Future PRs will merge the expression and walk style menu creation in the main iteration loop of EmoteData. We can then generify the menu creation to be based on category rather than EmoteType, allowing for custom categories rather than hard coding menus based on EmoteType.