### PR TITLE
Disable Control Fix

### DIFF
--- a/client/Handsup.lua
+++ b/client/Handsup.lua
@@ -15,6 +15,14 @@ local function HandsUpLoop()
                 end)
             end
 
+            if not IsEntityPlayingAnim(PlayerPedId(), "random@mugging3", "handsup_standing_base", 49) then
+                ClearPedSecondaryTask(PlayerPedId())
+                CreateThread(function()
+                    Wait(350)
+                    InHandsup = false
+                end)
+            end
+
             Wait(0)
         end
     end)


### PR DESCRIPTION
If the animation is canceled without lowering your hand yourself, it disables the controls and stays that way; if your hands are lowered, it breaks the code.