### PR TITLE
fix (previewPed): Don't despawn non-net entities

### DIFF
--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -150,7 +150,7 @@ local function preparePreviewPed(startPosition, emoteName)
     SetEntityAlpha(previewPed, 150, false)
     FreezeEntityPosition(previewPed, true)
     SetEntityRotation(previewPed, 0, 0, 0, 2, false)
-    SetEntityCoordsNoOffset(previewPed, startPosition.x, startPosition.y, startPosition.z - 50, true, true, true)
+    SetEntityCoords(previewPed, startPosition.x, startPosition.y, startPosition.z - 50, false, false, false, false)
     EmotePlayOnNonPlayerPed(previewPed, emoteName)
 end
 
@@ -213,7 +213,7 @@ local function positionPreviewPed(emoteName)
                 end
 
                 SetEntityHeading(previewPed, initHeading + rotateAmount)
-                SetEntityCoordsNoOffset(previewPed, possiblePosition.x, possiblePosition.y, possiblePosition.z, true, true, true)
+                SetEntityCoords(previewPed, possiblePosition.x, possiblePosition.y, possiblePosition.z - 1, false, false, false, false)
             end
 
             disableControls()

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -413,7 +413,7 @@ function ShowPedMenu(zoom)
                 end
                 averagedTarget = averagedTarget / #positionBuffer
 
-                SetEntityCoords(ClonedPed, averagedTarget.x, averagedTarget.y, averagedTarget.z, false, false, false, true)
+                SetEntityCoords(ClonedPed, averagedTarget.x, averagedTarget.y, averagedTarget.z, false, false, false, false)
                 local heading_offset = Config.MenuPosition == "left" and 170.0 or 190.0
                 SetEntityHeading(ClonedPed, camRot.z + heading_offset)
                 SetEntityRotation(ClonedPed, camRot.x * (-1), 0.0, camRot.z + 170.0, 2, false)


### PR DESCRIPTION
This PR aim to fix the current bug / exploit in previewPed, and World Placement previewPed, where the collision between the ped and non-networked / not-needed entitites (like traffic) would cause the said entitites to despawn.

This fixes (#174)

RCA:
* The menu previewPed creation had the `clearArea` param set to true in `Utils`. This causes the game to clear the area of any non-essentials entities that might collide with the ped that we are about to teleport.
* In the world placement script, we move the previewPed with the `SetEntityCoordsNoOffset()` native instead, and while this native does not have a `clearArea` param, it seems to do the same thing.

Fix: Changed the native in `Placement.lua`, and fix the wrong param in `Utils.lua` 