### PR TITLE
fix: menu fixes

### DIFF
--- a/NativeUI.lua
+++ b/NativeUI.lua
@@ -3596,8 +3596,10 @@ function UIMenu:UpdateScaleform()
         return
     end
 
-    local showEmoteButtons = LastEmote and LastEmote.name
-    -- local showEmoteButtons = true
+    local showEmoteButtons = CurrentMenuSelection and CurrentMenuSelection.name and CurrentMenuSelection.emoteType
+        and CurrentMenuSelection.emoteType ~= EmoteType.EXPRESSIONS
+        and CurrentMenuSelection.emoteType ~= EmoteType.WALKS
+        and CurrentMenuSelection.emoteType ~= EmoteType.SHARED
 
     PushScaleformMovieFunction(self.InstructionalScaleform, "CLEAR_ALL")
     PopScaleformMovieFunction()
@@ -3653,6 +3655,14 @@ function UIMenu:UpdateScaleform()
         PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 176, 0))
         PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 21, 0))
         PushScaleformMovieFunctionParameterString(Translate('btn_place'))
+        PopScaleformMovieFunction()
+        count = count + 1
+
+        PushScaleformMovieFunction(self.InstructionalScaleform, "SET_DATA_SLOT")
+        PushScaleformMovieFunctionParameterInt(count)
+        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 176, 0))
+        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 36, 0))
+        PushScaleformMovieFunctionParameterString(Translate('btn_groupselect'))
         PopScaleformMovieFunction()
         count = count + 1
     end

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -409,7 +409,7 @@ function EmotePlayOnNonPlayerPed(ped, name)
     local emoteData = EmoteData[name]
     local animOption = emoteData.AnimationOptions
 
-    LastEmote = {name = name}
+    LastEmote = {name = name, emoteType = emoteData.emoteType}
 
     if animOption and animOption.Prop then
         DestroyAllProps(true)

--- a/client/GroupEmote.lua
+++ b/client/GroupEmote.lua
@@ -42,6 +42,7 @@ local function setGroupArea(emotename, initialRadius)
         if IsDisabledControlJustPressed(2, 202) then
             returnRadius = -1 -- Cancel event.
             waitForInput = false
+            Wait(100) -- Prevent double backspace from affecting menu navigation
         end
 
         Wait(0)


### PR DESCRIPTION
- allow closing preview placement with backspace
- make the control buttons for group/placeable consistently show only on group/placeable emotes, and not on other menu items
- Hide menu during place preview
- Fix issue where control buttons were not showing when first entering a menu