### PR TITLE
Fixes preview ped prop attaching to player

### DIFF
--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -269,6 +269,7 @@ local function positionPreviewPed(emoteName)
             Wait(0)
         end
 
+        DestroyAllProps(true)
         DeleteEntity(previewPed)
         walkPedToPlacementPosition(emoteName)
     end)

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -498,7 +498,7 @@ AddStateBagChangeHandler('rpemotes:props', nil, function(bagName, key, value, re
         end
         DebugPrint("time to finish loading ped (ms)", GetGameTimer() - gameTime)
         local emoteData = value.emoteType == EmoteType.SHARED and SharedEmoteData[value.Emote] or EmoteData[value.Emote]
-        addProps(emoteData.AnimationOptions, value.TextureVariation or nil, false, ply)
+        addProps(emoteData.AnimationOptions, value.TextureVariation or nil, -1, ply)
     end
 end)
 


### PR DESCRIPTION
The diffs look a bit messy unfortunately, but this PR updates existing prop creation functions to allow for prop creation on the placement preview ped, without affecting existing clone and player ped prop creation.