### PR TITLE
feat: default model compatibility to only emotes not associated to a compat group

### DIFF
--- a/shared/ModelCompat.lua
+++ b/shared/ModelCompat.lua
@@ -76,14 +76,23 @@ for group, emotes in pairs(emoteCompatibility) do
     end
 end
 
+--- Build a set of all emotes assigned to any compat group
+---@type table<string, boolean>
+local emotesInCompatGroups = {}
+for _, emotes in pairs(emoteCompatibilitySets) do
+    for emoteName, _ in pairs(emotes) do
+        emotesInCompatGroups[emoteName] = true
+    end
+end
+
 ---@param model integer The model hash
 ---@param emoteName string The name of the emote
 ---@return boolean compatible True if the model can use the emote
 function IsModelCompatible(model, emoteName)
-    -- Models not in the list are compatible with all emotes
+    -- Models not in the list are only compatible with emotes not in any compat group
     local compatGroup = models[model]
     if not compatGroup then
-        return true
+        return not emotesInCompatGroups[emoteName]
     end
 
     -- Check if the emote is allowed for this group or any ancestor


### PR DESCRIPTION
This allows us to avoid listing all emotes a human needs to use at first, making the model compat useful for exclusive emotes. Once we have a common emote though, we'll then need a common compat group, requiring listing all human emotes in a list.