### PR TITLE
feat: Favorite Emotes

### DIFF
--- a/NativeUI.lua
+++ b/NativeUI.lua
@@ -3600,13 +3600,16 @@ function UIMenu:UpdateScaleform()
         return
     end
 
+    local favoriteEmotes = GetFavoriteEmotes()
     local showEmoteButtons = CurrentMenuSelection and CurrentMenuSelection.name and CurrentMenuSelection.emoteType
         and CurrentMenuSelection.emoteType ~= EmoteType.EXPRESSIONS
         and CurrentMenuSelection.emoteType ~= EmoteType.WALKS
         and CurrentMenuSelection.emoteType ~= EmoteType.SHARED
+        and CurrentMenuSelection.emoteType ~= EmoteType.EMOJI
 
     local showKeybindButtons = (keybindMenu and keybindMenu.menu:Visible()) or (CurrentMenuSelection and CurrentMenuSelection.name and CurrentMenuSelection.emoteType)
-
+    local showFavoriteButton = CurrentMenuSelection and CurrentMenuSelection.name and CurrentMenuSelection.emoteType
+    
     PushScaleformMovieFunction(self.InstructionalScaleform, "CLEAR_ALL")
     PopScaleformMovieFunction()
 
@@ -3651,6 +3654,19 @@ function UIMenu:UpdateScaleform()
         PushScaleformMovieFunctionParameterInt(count)
         PushScaleformMovieFunctionParameterString(GetControlInstructionalButton(2, 199, 0))
         PushScaleformMovieFunctionParameterString(Translate('btn_increment')..(paginationValue and ': '..paginationValue or ": "..paginationValue))
+        PopScaleformMovieFunction()
+        count = count + 1
+    end
+
+    if showFavoriteButton then
+        PushScaleformMovieFunction(self.InstructionalScaleform, "SET_DATA_SLOT")
+        PushScaleformMovieFunctionParameterInt(count)
+        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 121, 0))
+        if favoriteEmotes[CurrentMenuSelection.emoteType.."_"..CurrentMenuSelection.name] then
+            PushScaleformMovieFunctionParameterString(Translate("btn_remove_favorite"))
+        else
+            PushScaleformMovieFunctionParameterString(Translate("btn_set_favorite"))
+        end
         PopScaleformMovieFunction()
         count = count + 1
     end

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -13,6 +13,7 @@ WalkData = {}
 local isMenuProcessing = false
 local isWaitingForPed = false
 keybindMenu = nil -- Global variable. Scary!
+favoriteMenu = nil -- Global variable. Scary!
 local dataForKeybind = {}
 
 -- Tracks currently selected menu item for instruction button visibility
@@ -55,7 +56,7 @@ local function addEmoteToMenu(menu, items, emoteName, label, description, emoteT
     local hasPermission = HasEmotePermission(emoteName, emoteType)
     item:Enabled(hasPermission)
     menu:AddItem(item)
-    items[#items+1] = {name = emoteName, emoteType = emoteType}
+    items[#items+1] = {name = emoteName, emoteType = emoteType, label = label}
 end
 
 local function formatSharedEmoteDescription(emoteName, secondPlayersAnim)
@@ -318,11 +319,13 @@ local function onMenuItemHover(currentMenu)
 
     local emoteName = subMenuData.items[currentIndex].name
     local emoteType = subMenuData.items[currentIndex].emoteType
+    local emoteLabel = subMenuData.items[currentIndex].label
 
     -- Always update CurrentMenuSelection for instruction buttons
     CurrentMenuSelection = {
         name = emoteName,
         emoteType = emoteType,
+        label = emoteLabel,
     }
 
     -- Force scaleform refresh to update instruction buttons
@@ -462,6 +465,36 @@ local function addKeybindMenu(parent)
     return menu
 end
 
+local function addFavoritesMenu(parent)
+    if parent then -- Hack-job to allow us to use the same function for both creating and rebuilding the menu.
+        createSubMenu(parent, "favorites", Translate("favorites"), Translate("favoritesinfo"))
+    end
+    local menu = subMenus["favorites"]
+    local favoriteEmotes = GetFavoriteEmotes()
+    local favoriteEmotesMap = GetFavoriteEmotesMap()
+    for _, key in pairs(favoriteEmotesMap) do
+        local emoteData = favoriteEmotes[key]
+        local label = string.format("~b~%s~s~ %s", (emoteData and EmoteTypeEmoji[emoteData.emoteType]) or "", (emoteData and emoteData.label) or "Unknown Emote Name")
+        local item = NativeUI.CreateItem(label, "")
+        menu.menu:AddItem(item)
+        menu.items[#menu.items+1] = {name = emoteData.name, label = emoteData.label, emoteType = emoteData.emoteType}
+    end
+
+    menu.menu.OnItemSelect = function(_, __, index)
+        local item = menu.items[index]
+        -- If it's a regular emote, we go through the normal process.
+        local regularEmote = getEmoteData(item.name, item.emoteType)
+        if regularEmote and (item.emoteType ~= EmoteType.EXPRESSIONS and item.emoteType ~= EmoteType.WALKS) then
+            handleEmoteSelection(item.name, item.emoteType, item.textureVariation)
+            return
+        end
+        -- For Emojis got through the router
+        RouteEmoteToFunction(item.name, item.emoteType, item.textureVariation)
+    end
+
+    return menu
+end
+
 local function addEmoteMenu(menu)
     local emoteMenu = createSubMenu(menu, EmoteType.EMOTES, Translate('emotes'))
     if Config.Search then
@@ -505,7 +538,7 @@ local function addEmoteMenu(menu)
                         local shareitem = NativeUI.CreateItem(data.label, desc)
                         shareitem:Enabled(hasPermission)
                         categoryMenu.menu:AddItem(shareitem)
-                        categoryMenu.items[#categoryMenu.items+1] = {name = emoteName, emoteType = data.emoteType}
+                        categoryMenu.items[#categoryMenu.items+1] = {name = emoteName, emoteType = data.emoteType, label = data.label}
                     elseif data.emoteType == EmoteType.PROP_EMOTES then
                         local label = EMOTE_PREFIX[EmoteType.PROP_EMOTES] .. data.label
                         local propitem = data.AnimationOptions.PropTextureVariations and
@@ -513,7 +546,7 @@ local function addEmoteMenu(menu)
                             NativeUI.CreateItem(label, string.format("/e (%s)", emoteName))
                         propitem:Enabled(hasPermission)
                         categoryMenu.menu:AddItem(propitem)
-                        categoryMenu.items[#categoryMenu.items+1] = {name = emoteName, emoteType = data.emoteType}
+                        categoryMenu.items[#categoryMenu.items+1] = {name = emoteName, emoteType = data.emoteType, label = data.label}
                     else
                         -- EMOTES, DANCES, ANIMAL_EMOTES
                         local prefix = EMOTE_PREFIX[data.emoteType] or ""
@@ -763,35 +796,39 @@ local function addFaceMenu(menu)
     })
 end
 
-local function addEmojiMenu(menu)
-    if not Config.EmojiMenuEnabled then return end
-
-    emojiSubmenu = _menuPool:AddSubMenu(menu, Translate('emojis'), Translate('emojisdescription'), true, true)
-
+local function addEmojiMenu(parent)
+    if parent then -- Hack-job to allow us to use the same function for both creating and rebuilding the menu.
+        createSubMenu(parent, "emojis", Translate("emojis"), Translate("favoremojisdescriptionitesinfo"))
+    end
+    local menu = subMenus["emojis"]
     local sortedEmojis = {}
     for key, emoji in pairs(EmojiData) do
         sortedEmojis[#sortedEmojis + 1] = {key = key, emoji = emoji}
     end
     table.sort(sortedEmojis, function(a, b) return a.key < b.key end)
 
-    for _, emojiData in ipairs(sortedEmojis) do
-        local displayName = emojiData.emoji .. " " .. emojiData.key:gsub("_", " ")
-        local item = NativeUI.CreateItem(displayName, "")
-        emojiSubmenu:AddItem(item)
-
-        item.Activated = function(parentMenu, item)
-            -- Check for keybind request (K key)
-            if IsControlPressed(2, 311) then
-                dataForKeybind = {emoteName = emojiData.key, emoteType = EmoteType.EMOJI, label = emojiData.emoji}
-                RebuildKeybindEmoteMenu()
-                keybindMenu.menu:Visible(true)
-                return
-            end
-            dataForKeybind = {}
-
-            ShowEmoji(emojiData.key)
-        end
+    for index, emojiData in pairs(sortedEmojis) do
+        local label = emojiData.emoji .. " " .. emojiData.key:gsub("_", " ")
+        local item = NativeUI.CreateItem(label, "")
+        menu.menu:AddItem(item)
+        menu.items[#menu.items+1] = {name = emojiData.key, label = label, emoteType = EmoteType.EMOJI, key = index}
     end
+
+    menu.menu.OnItemSelect = function(_, __, index)
+        -- Check for keybind request (K key)
+        local item = menu.items[index]
+        if IsControlPressed(2, 311) then
+            dataForKeybind = {emoteName = sortedEmojis[item.key].key, emoteType = EmoteType.EMOJI, label = sortedEmojis[item.key].emoji}
+            RebuildKeybindEmoteMenu()
+            keybindMenu.menu:Visible(true)
+            return
+        end
+        dataForKeybind = {}
+
+        ShowEmoji(sortedEmojis[item.key].key)
+    end
+
+    return menu
 end
 
 local function updateEmojiMenuAvailability()
@@ -812,6 +849,21 @@ local function processMenu()
     while _menuPool:IsAnyMenuOpen() do
         _menuPool:ProcessMenus()
         DisableControlAction(0, 36, true) -- Ducking, to not conflict with group emotes keybind
+        if IsControlJustPressed(2,121) then -- Set as Favorites
+            if CurrentMenuSelection and CurrentMenuSelection.name and CurrentMenuSelection.emoteType then
+                local emoteData = {
+                    id = CurrentMenuSelection.emoteType.."_"..CurrentMenuSelection.name,
+                    name = CurrentMenuSelection.name,
+                    emoteType = CurrentMenuSelection.emoteType,
+                    label = CurrentMenuSelection.label or CurrentMenuSelection.name,
+                    textureVariation = CurrentMenuSelection.textureVariation or 1
+                }
+                ToggleFavoriteEmote(emoteData.id, emoteData)
+                RebuildFavoritesEmoteMenu()
+                local currentMenu = GetCurrentlyVisibleMenu()
+                currentMenu:UpdateScaleform()
+            end
+        end
         Wait(0)
     end
     isMenuProcessing = false
@@ -995,6 +1047,7 @@ function InitMenu()
     if Config.Keybinding then
         keybindMenu = addKeybindMenu(mainMenu)
     end
+    favoriteMenu = addFavoritesMenu(mainMenu)
     if Config.WalkingStylesEnabled then
         addWalkMenu(mainMenu)
     end
@@ -1060,6 +1113,22 @@ function RebuildKeybindEmoteMenu()
     keybindMenu = addKeybindMenu()
 
     DebugPrint("Keybind Menu rebuilt at runtime")
+end
+
+function RebuildFavoritesEmoteMenu()
+    -- Clear all the items from the menu
+    for i = #favoriteMenu.menu.Items, 1, -1 do
+        favoriteMenu.menu:RemoveItemAt(i)
+    end
+    favoriteMenu.items = {}
+
+    -- Reset menu selection to avoid index out of bounds
+    favoriteMenu.menu.ActiveItem = 1000
+
+    -- Rebuild the menu
+    favoriteMenu = addFavoritesMenu()
+
+    DebugPrint("Favorite Menu rebuilt at runtime")
 end
 
 CreateThread(function()

--- a/client/Favorites.lua
+++ b/client/Favorites.lua
@@ -1,0 +1,60 @@
+local favoriteEmotes = {}
+local emotesKeySort = {} -- index list, to sort emotes by label
+local kvpKey = string.format('%s_favorites', Config.keybindKVP)
+
+local function saveFavoriteEmotes()
+    SetResourceKvpNoSync(kvpKey, json.encode(favoriteEmotes))
+end
+
+local function sortFavoriteEmotes()
+    -- This function might be slow when a player has hundreds of saved emotes, but it's needed
+    --      if we want the Favorites tab to be sorted.
+    -- This function runs once when the player joins the server, and then it's called
+    --      every time a saved emote is added or removed.
+
+    -- We first get all the saved emotes, into an index list.
+    emotesKeySort = {}
+    for key,_ in pairs(favoriteEmotes) do
+        emotesKeySort[#emotesKeySort+1] = key
+    end
+
+    -- Then we sort the index list based on the `label` value inside the main table.
+    table.sort(emotesKeySort, function(a, b)
+        return favoriteEmotes[a].label < favoriteEmotes[b].label
+    end)
+end
+
+Citizen.CreateThread(function()
+    -- Load the initial favorite emotes from the KVP.
+    favoriteEmotes = GetResourceKvpString(kvpKey)
+    if favoriteEmotes then favoriteEmotes = json.decode(favoriteEmotes) end
+    if not favoriteEmotes then
+        favoriteEmotes = {}
+    end -- If there are no favorites saved, treat as empty table.
+    sortFavoriteEmotes() -- full array passthrough AND table.sort. Scary when `favoriteEmotes` contains many items!
+end)
+
+-- Getters for the favorite emotes table, and the associated index list.
+function GetFavoriteEmotes()
+    return favoriteEmotes
+end
+function GetFavoriteEmotesMap()
+    return emotesKeySort
+end
+
+function ToggleFavoriteEmote(id, emoteData)
+    if favoriteEmotes[id] then
+        favoriteEmotes[id] = nil
+        sortFavoriteEmotes()
+        --  FIXME: This can slowly fill up the JSON with nulls.
+        --  While this is not a problem for LUA (since the decoder just ignores them),
+        --      it might be a problem if a server owner wants to send this JSON to NUI.
+
+        SimpleNotify(Translate("removedfromfavorites", emoteData.label))
+    else
+        favoriteEmotes[id] = emoteData
+        sortFavoriteEmotes()
+        SimpleNotify(Translate("addedtofavorites", emoteData.label))
+    end
+    saveFavoriteEmotes()
+end

--- a/client/Keybinds.lua
+++ b/client/Keybinds.lua
@@ -27,34 +27,13 @@ end
 
 -- BINDING EMOTES TO KEYS
 if Config.Keybinding then
-    -- Helper function to route the binded emote to whatever function it needs to use (regular emote, shared emote, emoji, etc)
-    local function routeKeybindToEmote(emoteName, emoteType)
-        if emoteType == EmoteType.SHARED then
-            SendSharedEmoteRequest(emoteName)
-            return
-        end
-        if emoteType == EmoteType.EXPRESSIONS then
-            EmoteMenuStart(emoteName, nil, EmoteType.EXPRESSIONS)
-            return
-        end
-        if emoteType == EmoteType.WALKS then
-            WalkMenuStart(emoteName)
-            return
-        end
-        if emoteType == EmoteType.EMOJI then
-            ShowEmoji(emoteName)
-            return
-        end
-        EmoteCommandStart({ emoteName, 0 })
-    end
-
     for i = 1, #Config.KeybindKeys do
         local cmd = string.format('emoteSelect%s', i)
         RegisterCommand(cmd, function()
             local emote = GetResourceKvpString(string.format('%s_bind_%s', Config.keybindKVP, i))
             if emote and emote ~= "" then
                 emote = json.decode(emote)
-                routeKeybindToEmote(emote.emoteName, emote.emoteType)
+                RouteEmoteToFunction(emote.emoteName, emote.emoteType)
             end
         end, false)
         RegisterKeyMapping(cmd, Translate("keybind_slot", i), 'keyboard', Config.KeybindKeys[i])

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -381,6 +381,27 @@ function DoesPedVehicleHaveHandleBars(ped)
     return IsThisModelABike(vehicleModel) or IsThisModelAJetski(vehicleModel) or IsThisModelAQuadbike(vehicleModel) or IsThisModelABicycle(vehicleModel)
 end
 
+-- Helper function to route the binded emote to whatever function it needs to use (regular emote, shared emote, emoji, etc)
+function RouteEmoteToFunction(emoteName, emoteType, textureVariation)
+    if emoteType == EmoteType.SHARED then
+        SendSharedEmoteRequest(emoteName)
+        return
+    end
+    if emoteType == EmoteType.EXPRESSIONS then
+        EmoteMenuStart(emoteName, nil, EmoteType.EXPRESSIONS)
+        return
+    end
+    if emoteType == EmoteType.WALKS then
+        WalkMenuStart(emoteName)
+        return
+    end
+    if emoteType == EmoteType.EMOJI then
+        ShowEmoji(emoteName)
+        return
+    end
+    EmoteCommandStart({ emoteName, textureVariation or 1 })
+end
+
 ----------------------------------------------------------------------
 
 ShowPed = false

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -51,6 +51,7 @@ client_scripts {
     'client/Expressions.lua',
     'client/Handsup.lua',
     'client/Keybinds.lua',
+    'client/Favorites.lua',
     'client/NewsCam.lua',
     'client/NoIdleCam.lua',
     'client/Pointing.lua',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -32,6 +32,8 @@ Locales['en'] = {
     ['nocancel'] = "No emote to cancel.",
     ['maleonly'] = "This emote is male only, sorry!",
     ['emotemenucmd'] = "Use command /emotemenu to open animations menu.",
+    ['favorites'] = "🌟 Favorites",
+    ['favoritesinfo'] = "Your saved emotes, walk styles, moods and emoji reactions.",
     ['shareemotes'] = "👫 Shared Emotes",
     ['shareemotesinfo'] = "Invite a nearby person to emote",
     ['notvalidsharedemote'] = "is not a valid shared emote.",
@@ -116,5 +118,10 @@ Locales['en'] = {
     ['refusedgroupemote'] = "You refused the group emote.",
     ['canceledgroupemote'] = "You canceled the group emote.",
     ['cannotstartgroupemote'] = "You cannot start another group emote!",
-    ['groupemoteradiushelp'] = "Select the area of the group emote for ~g~%s~w~.\n~INPUT_WEAPON_WHEEL_NEXT~~INPUT_WEAPON_WHEEL_PREV~ Change Radius\n~INPUT_FRONTEND_ACCEPT~ Select  |  ~INPUT_FRONTEND_RRIGHT~ Cancel"
+    ['groupemoteradiushelp'] = "Select the area of the group emote for ~g~%s~w~.\n~INPUT_WEAPON_WHEEL_NEXT~~INPUT_WEAPON_WHEEL_PREV~ Change Radius\n~INPUT_FRONTEND_ACCEPT~ Select  |  ~INPUT_FRONTEND_RRIGHT~ Cancel",
+    -- Favorites
+    ['btn_set_favorite'] = "Set Favorite",
+    ['btn_remove_favorite'] = "Remove Favorite",
+    ['addedtofavorites'] = "Emote (~g~%s~s~) added to favorites!",
+    ['removedfromfavorites'] = "Emote (~g~%s~s~) removed from favorites!",
 }


### PR DESCRIPTION
This PR aims to add a proper Favorite Emotes tab to the RPEmotes Menu.
The player can press `Insert` while hovering over any emote, walk, mood, dance or emoji in the menu, and it will add said item to the favorites tab. While hovering a favorited emote, the player can press `Insert` again, and clear that emote from Favorites.

Unlike the Keybinds tab, the Favorites tab allows the same emote actions as the regular menus (group emote, placement emote, set keybind, and removal of the emote from favorites).

This fixes #196 

## Features:
* Added Favorite emotes feature
* Added Favorites tab to the main menu.

## Refactors:
* Rewrote `addEmojiMenu()` function to use the `createSubMenu()` menu builder. This allows us to treat emojis like any other emote type. 
* Moved and renamed function `Keybinds/routeKeybindToEmote()` to `Utils/RouteEmoteToFunction()`. This allows us to automatically route emotes to their correct functions based on their `EmoteType`.
* Added 3rd param `textureVariation` to `RouteEmoteToFunction()` function, to properly pass the TextureVariation needed for the emote.