### PR TITLE
fix (Favorites): Better menu update when removing favorites

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -1130,16 +1130,23 @@ function RebuildFavoritesEmoteMenu()
     favoriteMenu = addFavoritesMenu()
     if #favoriteMenu.items > 0 then
         if favoriteMenu.items[cacheActiveItem] then
+            -- There is still an item at the cached index, so select it.
             favoriteMenu.menu:CurrentSelection(cacheActiveItem)
         else
+            -- If there are no items at the cached index, select the last item in the menu.
             favoriteMenu.menu:CurrentSelection(#favoriteMenu.items)
         end
+
+        -- We use the internal NativeUI functions to simulate a menu update.
+        -- Otherwise NativeUI wont't be able to update the menu, until the player does any action,
+        -- because :CurrentSelection() function doesn't update it by default.
         if favoriteMenu.menu.ActiveItem > 1 then
             favoriteMenu.menu:GoUp()
         else
             favoriteMenu.menu:GoDown()
         end
     else
+        -- No emotes to select. Clear the cached emote data.
         CurrentMenuSelection = {}
     end
 


### PR DESCRIPTION
Fixes for the Favorites tab feature:
* The player can no longer favorite the Reset buttons for Expressions or Walks.
* The Favorites tab menu updates correctly when the player removes an emote.