### PR TITLE
feat: ace perms config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -123,6 +123,13 @@ if Config.SharedEmotesEnabled then
     }
 end
 
+-- Require ace perms to use certain emotes.
+---@type table<string, table<EmoteType, string[]>>
+Config.Ace = {
+    -- Example: only players with ACE group.admin can use the drunk emote. Anyone can still use the drunk walk however.
+    --['group.admin'] = {[EmoteType.EMOTES] = {'drunk'}} 
+}
+
 Config.KeybindKeys = {
     'NUMPAD4',
     'NUMPAD5',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -27,7 +27,6 @@ shared_scripts {
     'locales/*.lua',
     'config.lua',
     'shared/ModelCompat.lua',
-    'animals.lua'
 }
 
 server_scripts {

--- a/types.lua
+++ b/types.lua
@@ -51,7 +51,7 @@ PlacementState = {
     IN_ANIMATION = 'In Animation'
 }
 
--- Mapping of EmoteTypes to the 4 ACE categories
+-- Mapping of EmoteTypes to the 5 ACE categories
 AceCategoryFromEmoteType = {
     [EmoteType.EMOTES] = EmoteType.EMOTES,
     [EmoteType.PROP_EMOTES] = EmoteType.EMOTES,
@@ -61,6 +61,7 @@ AceCategoryFromEmoteType = {
     [EmoteType.SHARED] = EmoteType.SHARED,
     [EmoteType.EXPRESSIONS] = EmoteType.EXPRESSIONS,
     [EmoteType.WALKS] = EmoteType.WALKS,
+    [EmoteType.EMOJI] = EmoteType.EMOJI,
 }
 
 


### PR DESCRIPTION
Switches from a purely ACE based system to a hybrid ACE + Config.

This is to make the default state that everyone has permissions to avoid extra work to explicitly give all players permissions to emotes. It also makes configuring exclusive emotes easier. In a purely ACE world, one has to either explicitly give permissions for every emote, or has to add all emotes with a wildcard, and then remove specific ones that would be exclusive before adding them to a different ace group.

Although the config maps ace to emotes, the code lookup is the opposite, so we reverse this mapping and store it in memory for fast lookups.