### PR TITLE
Adjust prop alpha to match target entity

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -449,7 +449,7 @@ function EmotePlayOnNonPlayerPed(ped, name)
     RemoveAnimDict(emoteData.dict)
 
     if not animOption or not animOption.Prop then return end
-    addProps(animOption, nil, ped, nil)
+    addProps(animOption, nil, ped)
 end
 
 function EmoteMenuStartClone(name, emoteType)


### PR DESCRIPTION
When adding a prop, its alpha is now set to match the target entity's alpha if it is less than 255. Also updated addProps call to include an additional argument for non-player peds.