### PR TITLE
Add conditional enter animation for emote preview ped

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -230,6 +230,7 @@ function EmoteCancel(force)
                 DebugPrint("Exit emote was invalid")
                 IsInAnimation = false
                 ClearPedTasks(ped)
+                EmoteCancelPlaying = false
                 return
             end
 
@@ -255,6 +256,8 @@ function EmoteCancel(force)
         DestroyAllProps()
 
         if GetPlacementState() == PlacementState.IN_ANIMATION then CleanUpPlacement(ped) end
+    else
+        EmoteCancelPlaying = false
     end
     cleanScenarioObjects(PlayerPedId())
     AnimationThreadStatus = false
@@ -402,11 +405,6 @@ function EmotePlayOnNonPlayerPed(ped, name)
         return false
     end
 
-    if Config.CancelPreviousEmote and not ExitAndPlay and not EmoteCancelPlaying then
-        ExitAndPlay = true
-        DebugPrint("Canceling previous emote and playing next emote")
-        return
-    end
 
     local emoteData = EmoteData[name]
     local animOption = emoteData.AnimationOptions
@@ -572,6 +570,10 @@ local function playExitAndEnterEmote(name, textureVariation, emoteType)
     ExitAndPlay = true
     DebugPrint("Canceling previous emote and playing next emote")
     local ped = PlayerPedId()
+    
+    CheckStatus = false
+    AnimationThreadStatus = false
+    
     exitScenario()
 
     PtfxNotif = false
@@ -583,16 +585,20 @@ local function playExitAndEnterEmote(name, textureVariation, emoteType)
     end
     DetachEntity(ped, true, false)
     CancelSharedEmote()
+    DestroyAllProps()
 
-    if CurrentAnimOptions?.ExitEmote then
-        local options = CurrentAnimOptions or {}
+    if CurrentAnimOptions and CurrentAnimOptions.ExitEmote then
+        local options = CurrentAnimOptions
 
         if not EmoteData[options.ExitEmote] then
             DebugPrint("Exit emote was invalid")
             ClearPedTasks(ped)
             IsInAnimation = false
+            ExitAndPlay = false
+            OnEmotePlay(name, textureVariation, emoteType)
             return
         end
+        
         OnEmotePlay(options.ExitEmote)
         DebugPrint("Playing exit animation")
 
@@ -601,19 +607,24 @@ local function playExitAndEnterEmote(name, textureVariation, emoteType)
             InExitEmote = true
             SetTimeout(animationOptions.EmoteDuration, function()
                 InExitEmote = false
-                DestroyAllProps(true)
                 ClearPedTasks(ped)
                 OnEmotePlay(name, textureVariation, emoteType)
                 ExitAndPlay = false
             end)
+            return
+        else
+            -- Exit emote has no duration, skip it and play new emote directly
+            ClearPedTasks(ped)
+            IsInAnimation = false
+            ExitAndPlay = false
+            OnEmotePlay(name, textureVariation, emoteType)
             return
         end
     else
         ClearPedTasks(ped)
         IsInAnimation = false
         ExitAndPlay = false
-        DestroyAllProps(true)
-        OnEmotePlay(name, CurrentTextureVariation, emoteType)
+        OnEmotePlay(name, textureVariation, emoteType)
     end
 end
 
@@ -655,8 +666,9 @@ function OnEmotePlay(name, textureVariation, emoteType)
         return false
     end
 
-    cleanScenarioObjects(PlayerPedId())
+    CheckStatus = false
 
+    cleanScenarioObjects(PlayerPedId())
     local inVehicle = IsPedInAnyVehicle(PlayerPedId(), true)
     Pointing = false
 


### PR DESCRIPTION
Introduces logic to skip the enter animation when playing emotes on the preview ped by checking if the ped is ClonedPed. The playEnterAnim flag is now set based on whether the ped is a preview ped, improving emote preview behavior.