### PR TITLE
Add option to strip GTA rich text formatting

### DIFF
--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -46,10 +46,18 @@ function HasEmotePermission(emoteName, emoteType)
     end
 end
 
+
+-- Helper function to strip GTA rich text formatting codes like ~y~, ~w~, ~g~, etc.
+local function StripRichText(message)
+    if not Config.StripRichText then return message end
+    return string.gsub(message, "~%a+~", "")
+end
 -- You can edit this function to add support for your favorite notification system
 function SimpleNotify(message)
+    message = StripRichText(tostring(message))
+
     if Config.NotificationsAsChatMessage then
-        TriggerEvent("chat:addMessage", { color = { 255, 255, 255 }, args = { tostring(message) } })
+        TriggerEvent("chat:addMessage", { color = { 255, 255, 255 }, args = { message } })
     else
         BeginTextCommandThefeedPost("STRING")
         AddTextComponentSubstringPlayerName(message)

--- a/config.lua
+++ b/config.lua
@@ -26,6 +26,7 @@ Config = {
     MaxEmojisPerPlayer = 3,     -- Max emojis that can stack (client-side)
     EmojiCooldownMs = 2500,     -- Cooldown between sends in ms (server-side)
     EmojiRange = 25.0, -- Distance in meters where emojis are visible
+    StripRichText = false, -- Set to true if using a custom notification system that doesn't support GTA rich text formatting
 
     -- Combat Car, and Player Movement
     DisarmPlayerOnEmote = false,


### PR DESCRIPTION
Introduced Config.StripRichText to optionally remove GTA rich text codes from notifications. Updated SimpleNotify to use a helper function for stripping formatting when enabled, improving compatibility with custom notification systems.