### PR TITLE
Increase ped preview height since most are shorter than humans

### DIFF
--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -461,7 +461,8 @@ function ShowPedMenu(zoom)
                 end
                 averagedTarget = averagedTarget / #positionBuffer
 
-                SetEntityCoords(ClonedPed, averagedTarget.x, averagedTarget.y, averagedTarget.z, false, false, false, false)
+                local zOffset = IsPedHuman(ClonedPed) and 0.0 or 0.5
+                SetEntityCoords(ClonedPed, averagedTarget.x, averagedTarget.y, averagedTarget.z + zOffset, false, false, false, false)                local heading_offset = Config.MenuPosition == "left" and 170.0 or 190.0
                 local heading_offset = Config.MenuPosition == "left" and 170.0 or 190.0
                 SetEntityHeading(ClonedPed, camRot.z + heading_offset)
                 SetEntityRotation(ClonedPed, camRot.x * (-1), 0.0, camRot.z + 170.0, 2, false)


### PR DESCRIPTION
Increase ped preview height in menu by 0.5, especially useful for dog and cat peds whose camera makes previews weird