### PR TITLE
fix: floating placed emotes

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -7617,6 +7617,7 @@ RP.Emotes = {
         AnimationOptions = {
             onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
+            PlacementOffsetZ = -1.0, -- Prevents floating during placement
         }
     },
     ["sittoilet"] = {

--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -90,7 +90,13 @@ local function walkPedToPlacementPosition(emoteName)
 
     positionPriorToPlacement = latestPedPosition
 
-    SetEntityCoordsNoOffset(playerPed, placementPosition.x, placementPosition.y, placementPosition.z, true, true, true)
+    local emoteData = EmoteData[emoteName]
+    local offset = 0
+    if emoteData and emoteData.AnimationOptions and emoteData.AnimationOptions.PlacementOffsetZ ~= nil then
+        offset = emoteData.AnimationOptions.PlacementOffsetZ
+    end
+
+    SetEntityCoordsNoOffset(playerPed, placementPosition.x, placementPosition.y, placementPosition.z + offset, true, true, true)
     SetEntityRotation(playerPed, placementRotation.x, placementRotation.y, placementRotation.z, 2, false)
     SetEntityHeading(playerPed, placementPosition.w)
 

--- a/types.lua
+++ b/types.lua
@@ -125,6 +125,7 @@ AceCategoryFromEmoteType = {
 ---@field ExitEmoteType? "Exits" deprecated. unused.
 ---@field BlendInSpeed? number
 ---@field BlendOutSpeed? number
+---@field PlacementZOffset? number offset to apply when using the placement feature. Needed for certain emotes which would otherwise be floating due to a built-in anim offset
 
 ---@class AnimationListConfig
 ---@field Expressions table<string, {[1]: AnimName, [2]: Label?}>


### PR DESCRIPTION
As far as I can tell, certain emotes have built-in offsets that only apply while the gravity disabled flag is set for an emote. We do this specifically when using the placement system, leading to certain emotes floating in the air. The solution is to teleport the player slightly down to cancel out this offset.

This PR adds a new config value to do so.