### PR TITLE
fix: add new flag PlacementOverridesPhysics

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -7617,7 +7617,8 @@ RP.Emotes = {
         AnimationOptions = {
             onFootFlag = AnimFlag.LOOP,
             ExitEmote = "offchair",
-            PlacementOffset = vector4(0, 0, -1.0, 0.0) -- Prevents floating during placement
+            PlacementOffset = vector4(0, 0, -1.0, 0.0), -- Prevents floating during placement
+            PlacementOverridesPhysics = true,
         }
     },
     ["sittoilet"] = {
@@ -8832,7 +8833,6 @@ RP.Emotes = {
         "Addict",
         AnimationOptions = {
             onFootFlag = AnimFlag.LOOP,
-            PlacementOffset = vector4(0.2, 2.0, -1.0, 220.0) -- correct the offset to zero it out
         }
     },
     ["handsup"] = {

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -810,7 +810,7 @@ function OnEmotePlay(name, textureVariation, emoteType)
 
     local flags = animOption?.Flag or movementType or 0
 
-    if GetPlacementState() == PlacementState.IN_ANIMATION then
+    if GetPlacementState() == PlacementState.IN_ANIMATION and animOption and animOption.PlacementOverridesPhysics then
         -- Override physics (allow floating off the ground) & Ragdoll on Collision
         flags += 1024 + 4194304
     elseif vehicleHasHandleBars then

--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -91,9 +91,11 @@ local function walkPedToPlacementPosition(emoteName)
     positionPriorToPlacement = latestPedPosition
 
     local emoteData = EmoteData[emoteName]
-    if emoteData and emoteData.AnimationOptions and emoteData.AnimationOptions.PlacementOffset ~= nil then
+    local animOptions = emoteData and emoteData.AnimationOptions
+
+    if animOptions and animOptions.PlacementOffset ~= nil then
         -- Apply offset relative to ped's heading
-        local offset = emoteData.AnimationOptions.PlacementOffset
+        local offset = animOptions.PlacementOffset
         local adjustedPosition = GetOffsetFromCoordAndHeadingInWorldCoords(
             placementPosition.x, placementPosition.y, placementPosition.z,
             placementPosition.w,  -- heading
@@ -112,7 +114,11 @@ local function walkPedToPlacementPosition(emoteName)
     placementState = PlacementState.IN_ANIMATION
 
     OnEmotePlay(emoteName)
-    checkCollisionsWhileInAnimation()
+
+    -- Only check collisions if overriding physics
+    if animOptions and animOptions.PlacementOverridesPhysics then
+        checkCollisionsWhileInAnimation()
+    end
 end
 
 local function disableControls()

--- a/types.lua
+++ b/types.lua
@@ -126,6 +126,7 @@ AceCategoryFromEmoteType = {
 ---@field BlendInSpeed? number
 ---@field BlendOutSpeed? number
 ---@field PlacementOffset? vector4 offset to apply when using the placement feature. Needed for certain emotes which have default offsets that need to be zeroed out
+---@field PlacementOverridesPhysics? boolean when true, applies flags to make an animation float, and handles collision in a custom way. This is to support animations over ledges where the ped would otherwise fall down.
 
 ---@class AnimationListConfig
 ---@field Expressions table<string, {[1]: AnimName, [2]: Label?}>


### PR DESCRIPTION
Since overriding physics comes with side effects that are unwanted, we only want to do so when needed. This PR introduces a flag to control for which emotes we override physics for when using the placement system. This is only needed for sitting emotes to let the ped sit over a ledge without falling down.