### PR TITLE
Prevent player from targeting preview/placement peds

### DIFF
--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -423,6 +423,7 @@ function StartNewPlacement(emoteName)
     SetBlockingOfNonTemporaryEvents(previewPed, true)
     SetEntityAlpha(previewPed, 254, false)
     SetEntityCollision(previewPed, false, false)
+    SetPedCanBeTargetted(ClonedPed, false)
 
     ClosePedMenu()
 

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -420,6 +420,7 @@ function ShowPedMenu(zoom)
             SetBlockingOfNonTemporaryEvents(ClonedPed, true)
             SetEntityAlpha(ClonedPed, 254, false)
             SetEntityCollision(ClonedPed, false, false)
+            SetPedCanBeTargetted(ClonedPed, false)
 
             ShowPed = true
 


### PR DESCRIPTION
Players could attempt to attack the preview ped, causing unintended movement  and behavior