### PR TITLE
fix (Placement): Fix animation offset desync

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -151,6 +151,7 @@ local function runAnimationThread()
 
             Wait(sleep)
         end
+        CleanUpPlacement(ped)
     end)
 end
 
@@ -812,7 +813,7 @@ function OnEmotePlay(name, textureVariation, emoteType)
 
     if GetPlacementState() == PlacementState.IN_ANIMATION and animOption and animOption.PlacementOverridesPhysics then
         -- Override physics (allow floating off the ground) & Ragdoll on Collision
-        flags += 1024 + 4194304
+        flags += 2048 + 4194304
     elseif vehicleHasHandleBars then
         -- Overrides flags to sync animations between clients and force only upperbody
         flags = 16 + 262144


### PR DESCRIPTION
## RCA:

Animation flag 1024 (`AF_OVERRIDE_PHYSICS`) seems to break anim sync in FiveM. Once a player starts an animation, their position seems to not sync between players (same behavior as ragdolls).

This, combined with the physics flag (that makes animations use their default offsets) will desync the player:
> 1. Player teleports themselves to even out the offset.
> 2. Player plays the anim for themselves, the anim is moved to the offset.
> 3. Offset position is replicated on all the clients.
> 4. The other clients replicate the same animation on the player, and *they are applying the same offset to the Player again*, but this time not synced.
> 5. Other clients cannot move the Player locally (non-synced), since it's a player ped, and they don't have access to that.
> 6. The Player is still in the "correct" spot for all clients, only the visual ped is different. So hitting the Player where they *should be* will still knock them out.

You can see this by not applying the offset correction yourself. If you do that, your client will offset the ped once, while the other clients will offset your player twice.

## Fix:
We remove the `1024` flag, and replace it to `AF_IGNORE_GRAVITY = 2048,`. This will allow us to use the animations like before, without even needing to correct the offset (because most anims don't use it by default).

We also freeze the player ped while in an placement animation. This allows us to place animation in places where otherwise players would fall off. This allows us to place sitting animations ledges for example (especially if the animation has the "ped origin" on the feet).

This fixes #226 

## Tests done:
* Player can set their placed emote in a normal position, and it will sync.
* Player can set their placed emote on a bench / roof ledge, and not fall off. It will also sync.
* Other players can knock-out peds in animations, and it will cancel them correctly.
* Normal anims still work as intended.

## Trade-offs and Known Issues:
1. Changes made will allow peds to place animations that are hovering in the air. For some reason this only replicates for other clients, and not for the initiating client. This only happens when the preview ped is shown as floating in the air, so in regular play, this won't be an issue.

2. There are instances where peds would show sitting correctly on the bench, but on the other clients they would show with a leg up, or hovering over the bench with their toes on the bench. This is not necessarily a problem with RPEmotes, but a problem with FiveM networking, since the player position isn't exactly accurate accross clients.
This leads to situations where the ped origin is just next to the bench on one client, but on top of the bench for other client.

3. Because we are freezing the ped, players will still be stuck in placed emotes that normally don't restrict the player movement. I am not sure if we have an use case for placeable emotes that don't restrict player movement, since there wouldn't be a point to place the emote then.

4. You can walk through peds that are in a placed animation. I think this is an existing issue. Haven't found a fix for it yet.