### PR TITLE
Remove preview ped on death

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -1207,6 +1207,7 @@ CreateThread(function()
                 EmoteCancel()
             end
             _menuPool:CloseAllMenus()
+            ClosePedMenu()  -- Clean up the preview ped
         end
 
         if Config.PreviewPed then


### PR DESCRIPTION
When the player dies and the menu is closed, we now hide the preview ped, which before would stay up on the player's screen even when menu was auto closed