### PR TITLE
Fix QB/QBX death/last stand checks

### DIFF
--- a/client/Bridge.lua
+++ b/client/Bridge.lua
@@ -55,8 +55,7 @@ function CanDoAction()
     if Framework == 'esx' then
         return PlayerLoaded and not PlayerData.dead
     elseif Framework == 'qb' then
-        return LocalPlayer.state.isLoggedIn and not (PlayerData.metadata.inlaststand or PlayerData.metadata.isdead)
-    end
+        return LocalPlayer.state.isLoggedIn and not (PlayerData.metadata.inlaststand or PlayerData.metadata.isdead or PlayerData.metadata.ishandcuffed)    end
     -- here you can implement your own standalone framework check
     return true
 end


### PR DESCRIPTION
Before, rpemotes-reborn would only check on start of the resource for death/last stand, so this was always broken for preventing menu use while dead and in last stand.

Added handcuff check