### PR TITLE
Reset inAction flag on crawl key press

### DIFF
--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -394,10 +394,12 @@ local function CrawlKeyPressed()
     end
 
     if InHandsup then
+        inAction = false
         return
     end
 
     if IsInActionWithErrorMessage({IsProne = true}) then
+        inAction = false
         return
     end
 


### PR DESCRIPTION
Sets inAction to false when crawl key is pressed and player is in handsup. Sometimes this would cause a conflict where someone could no longer crouch or no longer uncrouch.