### PR TITLE
fix: placement collision

### DIFF
--- a/server/Server.lua
+++ b/server/Server.lua
@@ -179,6 +179,11 @@ RegisterNetEvent("rpemotes:ptfx:sync", function(asset, name, offset, rot, bone, 
     state:set("ptfx", nil, true)
 end)
 
+RegisterNetEvent("rpemotes:server:syncHeading", function(heading)
+    local state = Player(source).state
+    state:set("emoteHeading", heading, true)
+end)
+
 local function ExtractEmoteProps(format)
     format = tonumber(format)
     local xt, c, total = '', '', 0


### PR DESCRIPTION
- Freezing for one frame only to restore collision for throwables
- Added a statebag sync for heading since it seems there are some rare cases where heading isn't synced by one sync within an animation.