### PR TITLE
fix(Placement): Disable placement keybind while running + Placement toggle config var

### DIFF
--- a/NativeUI.lua
+++ b/NativeUI.lua
@@ -3724,13 +3724,15 @@ function UIMenu:UpdateScaleform()
     end
 
     if showEmoteButtons then
-        PushScaleformMovieFunction(self.InstructionalScaleform, "SET_DATA_SLOT")
-        PushScaleformMovieFunctionParameterInt(count)
-        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 176, 0))
-        PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 21, 0))
-        PushScaleformMovieFunctionParameterString(Translate('btn_place'))
-        PopScaleformMovieFunction()
-        count = count + 1
+        if Config.PlacementEnabled then
+            PushScaleformMovieFunction(self.InstructionalScaleform, "SET_DATA_SLOT")
+            PushScaleformMovieFunctionParameterInt(count)
+            PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 176, 0))
+            PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(2, 21, 0))
+            PushScaleformMovieFunctionParameterString(Translate('btn_place'))
+            PopScaleformMovieFunction()
+            count = count + 1
+        end
 
         PushScaleformMovieFunction(self.InstructionalScaleform, "SET_DATA_SLOT")
         PushScaleformMovieFunctionParameterInt(count)

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -263,13 +263,15 @@ local function handleEmoteSelection(emoteName, emoteType, textureVariation)
         end
         dataForKeybind = {}
 
-        local shiftHeld = IsControlPressed(0, 21)
-        local movingForward = IsControlPressed(0,32) or IsControlPressed(0,31) or IsControlPressed(0,30) -- INPUT_MOVE_UP_ONLY or INPUT_MOVE_UP or INPUT_MOVE_LR
-        local placementState = GetPlacementState()
+        if Config.PlacementEnabled then
+            local shiftHeld = IsControlPressed(0, 21)
+            local movingForward = Config.DisablePlacementKeybindWhileMoving and (IsControlPressed(0,32) or IsControlPressed(0,31) or IsControlPressed(0,30)) -- INPUT_MOVE_UP_ONLY or INPUT_MOVE_UP or INPUT_MOVE_LR
+            local placementState = GetPlacementState()
 
-        if !movingForward and shiftHeld and placementState ~= PlacementState.PREVIEWING and placementState ~= PlacementState.WALKING then
-            StartNewPlacement(emoteName)
-            return
+            if !movingForward and shiftHeld and placementState ~= PlacementState.PREVIEWING and placementState ~= PlacementState.WALKING then
+                StartNewPlacement(emoteName)
+                return
+            end
         end
 
         EmoteMenuStart(emoteName, textureVariation, emoteType)

--- a/config.lua
+++ b/config.lua
@@ -104,6 +104,10 @@ Config = {
     CheckForUpdates = true,
     DebugDisplay = false,
 
+    -- Emote Placement
+    PlacementEnabled = true,
+    DisablePlacementKeybindWhileMoving = true, -- When true, you cannot enter placement mode while moving. This only affects the keybind.
+
 }
 
 -- Custom Categories: Define custom categories to organize emotes in the menu


### PR DESCRIPTION
This PR aims to block the placement keybind (`Shift + Enter`) while moving, as players would sometimes trigger the placement while running, and allow servers to disable the Placement mechanic in the config.

## RCA:
Power-user players would sometimes trigger the placement keybind (INPUT_SPRINT + INPUT_ENTER) while trying to start a normal animation, and run at the same time.

## Fix:
This PR checks if the player is moving, and disable the Placement keybind, allowing the player to start normal emotes even when holding Shift.
Servers can disable this fix in the cofing.
Also, servers can now fully disable the Placement mechanic in the config, if they don't wish to use it.