### PR TITLE
Fix: Small Typo

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -268,7 +268,7 @@ local function handleEmoteSelection(emoteName, emoteType, textureVariation)
             local movingForward = Config.DisablePlacementKeybindWhileMoving and (IsControlPressed(0,32) or IsControlPressed(0,31) or IsControlPressed(0,30)) -- INPUT_MOVE_UP_ONLY or INPUT_MOVE_UP or INPUT_MOVE_LR
             local placementState = GetPlacementState()
 
-            if movingForward and shiftHeld and placementState ~= PlacementState.PREVIEWING and placementState ~= PlacementState.WALKING then
+            if not movingForward and shiftHeld and placementState ~= PlacementState.PREVIEWING and placementState ~= PlacementState.WALKING then
                 StartNewPlacement(emoteName)
                 return
             end


### PR DESCRIPTION
Error parsing script @rpemotes-reborn/client/EmoteMenu.lua in resource rpemotes-reborn: @rpemotes-reborn/client/EmoteMenu.lua:271: unexpected symbol near '!'

^1SCRIPT ERROR: @rpemotes-reborn/client/Emote.lua:97: attempt to call a nil value (global 'RebuildEmoteMenu')^7
^3> fn^7 (^5@rpemotes-reborn/client/Emote.lua^7:97)

This small typo was causing these errors.