### PR TITLE
fix(Emotes): Better recovery for canceled anims

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -499,7 +499,7 @@ end
 
 function EmoteCommandStart(args)
     if #args <= 0 then return end
-    if IsEntityDead(PlayerPedId()) or IsPedRagdoll(PlayerPedId()) or IsPedGettingUp(PlayerPedId()) or IsPedInMeleeCombat(PlayerPedId()) then
+    if IsPedBusy(PlayerPedId()) then
         TriggerEvent('chat:addMessage', {
             color = { 255, 0, 0 },
             multiline = true,
@@ -915,7 +915,7 @@ local function recoverLostAnimation()
     pedBumpTimeout = 500
     -- We wait a bit to avoid collision with the ped resetting the animation again
     DebugPrint("Trying to recover...")
-    while pedBumpTimeout > 0 do
+    while pedBumpTimeout > 0 or IsPedBusy(pPed) do
         Wait(100)
         pedBumpTimeout = pedBumpTimeout - 100
     end

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -905,6 +905,7 @@ end)
 
 
 local function recoverLostAnimation()
+    if not Config.RecoverEmotesAfterRagdoll then return end
     local pPed = PlayerPedId()
     if isBumpingPed then
         timeout = 500
@@ -944,7 +945,6 @@ AddEventHandler("CEventPlayerCollisionWithPed", function(unk1)
 end)
 
 AddEventHandler("gameEventTriggered", function(eventName, eventData)
-    if not Config.RecoverEmotesAfterRagdoll then return end
     if eventName ~= "CEventNetworkEntityDamage" then return end
     if eventData[1] ~= PlayerPedId() then return end
     if not IsInAnimation then return end

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -926,7 +926,9 @@ local function recoverLostAnimation()
     end
     isBumpingPed = false
 
-    if GetIsTaskActive(pPed, 131) or GetIsTaskActive(pPed, 134) or GetIsTaskActive(pPed, 135) then
+    -- Check for Scripted Animation tasks.
+    -- See https://docs.fivem.net/natives/?_0xB0760331C7AA4155 for a list of tasks. Check types.lua for the enum.
+    if GetIsTaskActive(pPed, TaskType.MELEE_UPPERBODY_ANIMS) or GetIsTaskActive(pPed, TaskType.SCRIPTED_ANIMATIONS) or GetIsTaskActive(pPed, TaskType.SYNCHRONIZED_SCENE) then
         DebugPrint("Won't recover! Animation already playing!")
         return
     end

--- a/client/Placement.lua
+++ b/client/Placement.lua
@@ -20,7 +20,7 @@ local function checkForCollidingEntities(ped)
     local ray = StartExpensiveSynchronousShapeTestLosProbe(
         pedPosition.x, pedPosition.y, pedPosition.z,
         pedPosition.x, pedPosition.y, pedPosition.z - 2,
-        2 + 4 + 8, -- Vehicles, Peds, & Ragdolls
+        2, -- Check for vehicles only.
         ped, 7
     )
 

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -95,6 +95,10 @@ function IsPlayerAiming(player)
     tonumber(GetSelectedPedWeapon(player)) ~= tonumber(GetHashKey("WEAPON_UNARMED"))
 end
 
+function IsPedBusy(playerPed)
+    return IsEntityDead(playerPed) or IsPedRagdoll(playerPed) or IsPedGettingUp(playerPed) or IsPedInMeleeCombat(playerPed)
+end
+
 function CanPlayerCrouchCrawl(ped)
     return IsPedOnFoot(ped)
         and not IsPedJumping(ped)

--- a/config.lua
+++ b/config.lua
@@ -102,7 +102,7 @@ Config = {
 
     -- Developer Tools
     CheckForUpdates = true,
-    DebugDisplay = true,
+    DebugDisplay = false,
 
     -- Emote Placement
     PlacementEnabled = true,

--- a/config.lua
+++ b/config.lua
@@ -102,7 +102,7 @@ Config = {
 
     -- Developer Tools
     CheckForUpdates = true,
-    DebugDisplay = false,
+    DebugDisplay = true,
 
     -- Emote Placement
     PlacementEnabled = true,
@@ -110,6 +110,9 @@ Config = {
 
     -- Old Props Spawning
     UseOldPropSpawning = false, -- Uses networked objects spawned client-side, for props. Only use this when you have issues spawning props.
+
+    -- Recover Emotes after Ragdoll
+    RecoverEmotesAfterRagdoll = true -- If true, the resource will attempt to recover emotes after being bumped / ragdolled. Doesn't work for all.
 }
 
 -- Custom Categories: Define custom categories to organize emotes in the menu

--- a/types.lua
+++ b/types.lua
@@ -51,6 +51,13 @@ PlacementState = {
     IN_ANIMATION = 'In Animation'
 }
 
+---@enum TaskType
+TaskType = {
+    MELEE_UPPERBODY_ANIMS = 131,
+    SCRIPTED_ANIMATIONS = 134,
+    SYNCHRONIZED_SCENE = 135
+}
+
 -- Mapping of EmoteTypes to the 5 ACE categories
 AceCategoryFromEmoteType = {
     [EmoteType.EMOTES] = EmoteType.EMOTES,


### PR DESCRIPTION
This PR aims to provide a better way to recover lost emote animations due to bumping by the peds / ragdolling of the player ped, by checking if the animations needs to be recovered or not.

Hopefully fixes #284.

RCA:
---
Previous implementation simply checked for ped collision, and tried to reset the animation after that, without any other checks. While working in some very specific scenarios, this caused most (if not all) animations to simply cancel whenever a player or ped bumped the client player, due to a race condition in `checkStatusThread()` that canceled the animation.

Changes:
---
* Use both `CEventPlayerCollisionWithPed` and `CEventNetworkEntityDamage` events to check for oportunities to recover the anim. We do this because some punches or pushes don't actually trigger the physics collision.
* Changed recovery logic, to first check if the player is still in an animation task, before trying to restart. This fixes some annoyances with scenario animations.
* Added `RecoverEmotesAfterRagdoll` config value (default to True), in case servers want / need to opt out of the functionality.
* Modified `checkStatusThread()` function to check if the player is being bumped, before trying to cancel the animation.
* Changed Placement Emote collision check to just vehicles, as being collided by peds would have the same results as Root Cause.

More info:
---
Placement animations are tricky to balance / make feel right, since the the animating ped doesn't have a physics collision by itself (but can be punched / damaged), so we have to rely on `StartExpensiveSynchronousShapeTestLosProbe()` native to break the player out of it when hit by a vehicle.