### PR TITLE
feat (UI): Add NUI menu (v1)

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -508,7 +508,7 @@ local function addFavoritesMenu(parent)
         local item = NativeUI.CreateItem(label, "")
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = emoteData.name, label = emoteData.label, emoteType = emoteData.emoteType}
-        AddEmoteToNUIQueue({id = emoteData.name, emoteType = emoteData.emoteType, label = emoteData.label, isFavorite = true})
+        AddEmoteToNUIQueue({emoteName = emoteData.name, emoteType = emoteData.emoteType, label = emoteData.label, isFavorite = true, categoryName = "favorites", hasPermission = true})
     end
 
     menu.menu.OnItemSelect = function(_, __, index)
@@ -584,7 +584,7 @@ local function addEmoteMenu(menu)
                         local label = prefix .. data.label
                         addEmoteToMenu(categoryMenu.menu, categoryMenu.items, emoteName, label, string.format("/e (%s)", emoteName), data.emoteType)
                     end
-                    AddEmoteToNUIQueue({id = emoteName, emoteType = emoteType, label = data.label})
+                    AddEmoteToNUIQueue({emoteName = emoteName, emoteType = emoteType, label = data.label, categoryName = categoryName, hasPermission = hasPermission})
                     ::continue::
                 end
             end
@@ -608,7 +608,7 @@ local function addEmoteMenu(menu)
     for _, emoteName in ipairs(emotesList) do
         local data = EmoteData[emoteName]
         addEmoteToMenu(emoteMenu.menu, emoteMenu.items, emoteName, data.label, string.format("/e (%s)", emoteName), data.emoteType)
-        AddEmoteToNUIQueue({id = emoteName, emoteType = "Emotes", label = data.label})
+        AddEmoteToNUIQueue({emoteName = emoteName, emoteType = EmoteType.EMOTES, label = data.label, categoryName = EmoteType.EMOTES, hasPermission = true})
     end
 end
 
@@ -783,7 +783,7 @@ local function addResetableDataMenu(input)
         item:Enabled(hasPermission)
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = itemName, emoteType = input.emoteType}
-        AddEmoteToNUIQueue({id = itemName, emoteType = input.emoteType, label = label})
+        AddEmoteToNUIQueue({emoteName = itemName, emoteType = input.emoteType, label = label, categoryName = input.emoteType, hasPermission = true})
     end
 
     menu.menu.OnItemSelect = function(_, item, index)
@@ -866,7 +866,7 @@ local function addEmojiMenu(parent)
         local item = NativeUI.CreateItem(label, "")
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = emojiData.key, label = label, emoteType = EmoteType.EMOJI, key = index}
-        AddEmoteToNUIQueue({id = emojiData.key, emoteType = EmoteType.EMOJI, label = label})
+        AddEmoteToNUIQueue({emoteName = emojiData.key, emoteType = EmoteType.EMOJI, label = label, categoryName = EmoteType.EMOJI, hasPermission = true})
     end
 
     menu.menu.OnItemSelect = function(_, __, index)

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -495,6 +495,7 @@ local function addFavoritesMenu(parent)
         local item = NativeUI.CreateItem(label, "")
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = emoteData.name, label = emoteData.label, emoteType = emoteData.emoteType}
+        AddEmoteToNUIQueue({id = emoteData.name, emoteType = emoteData.emoteType, label = emoteData.label, isFavorite = true})
     end
 
     menu.menu.OnItemSelect = function(_, __, index)
@@ -570,6 +571,7 @@ local function addEmoteMenu(menu)
                         local label = prefix .. data.label
                         addEmoteToMenu(categoryMenu.menu, categoryMenu.items, emoteName, label, string.format("/e (%s)", emoteName), data.emoteType)
                     end
+                    AddEmoteToNUIQueue({id = emoteName, emoteType = emoteType, label = data.label})
                     ::continue::
                 end
             end
@@ -593,6 +595,7 @@ local function addEmoteMenu(menu)
     for _, emoteName in ipairs(emotesList) do
         local data = EmoteData[emoteName]
         addEmoteToMenu(emoteMenu.menu, emoteMenu.items, emoteName, data.label, string.format("/e (%s)", emoteName), data.emoteType)
+        AddEmoteToNUIQueue({id = emoteName, emoteType = "Emotes", label = data.label})
     end
 end
 
@@ -767,6 +770,7 @@ local function addResetableDataMenu(input)
         item:Enabled(hasPermission)
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = itemName, emoteType = input.emoteType}
+        AddEmoteToNUIQueue({id = itemName, emoteType = input.emoteType, label = label})
     end
 
     menu.menu.OnItemSelect = function(_, item, index)
@@ -849,6 +853,7 @@ local function addEmojiMenu(parent)
         local item = NativeUI.CreateItem(label, "")
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = emojiData.key, label = label, emoteType = EmoteType.EMOJI, key = index}
+        AddEmoteToNUIQueue({id = emojiData.key, emoteType = EmoteType.EMOJI, label = label})
     end
 
     menu.menu.OnItemSelect = function(_, __, index)
@@ -930,15 +935,19 @@ function OpenEmoteMenu()
         RebuildKeybindEmoteMenu()
     end
 
-    if _menuPool:IsAnyMenuOpen() then
-        _menuPool:CloseAllMenus()
+    if Config.UseNUIMenu then
+        ToggleNUIMenu()
     else
-        -- Clean up any existing preview before opening
-        if hasClonedPed() then
-            ClosePedMenu()
+        if _menuPool:IsAnyMenuOpen() then
+            _menuPool:CloseAllMenus()
+        else
+            -- Clean up any existing preview before opening
+            if hasClonedPed() then
+                ClosePedMenu()
+            end
+            mainMenu:Visible(true)
+            processMenu()
         end
-        mainMenu:Visible(true)
-        processMenu()
     end
 end
 
@@ -1079,7 +1088,7 @@ local function convertRP()
 
     -- Expand custom categories after EmoteData is populated
     categoryToEmotes = expandCustomCategories()
-
+    TriggerEvent("rpemotes:internal:loadEmoteDataToNUI", EmoteData, categoryToEmotes)
     RP = nil
     CONVERTED = true
 end
@@ -1116,6 +1125,7 @@ function InitMenu()
     mainMenu.OnMenuClosed = function()
         ClosePedMenu()
     end
+    TriggerEvent("rpemotes:internal:sendMenuDataToNUI")
     _menuPool:RefreshIndex()
 end
 
@@ -1138,7 +1148,6 @@ function RebuildEmoteMenu()
 
     -- Rebuild the menu
     InitMenu()
-
     DebugPrint("Menu rebuilt for model compatibility")
 end
 

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -287,6 +287,51 @@ local function hidePreview()
     end
 end
 
+function CreatePreviewPed(emoteName, emoteType)
+    DebugPrint(emoteName, emoteType)
+    local emote = EmoteData[emoteName] or SharedEmoteData[emoteName]
+    if emoteType == EmoteType.EXPRESSIONS or (emote and isEmoteTypePreviewable(emote.emoteType)) then
+        DebugPrint("Emote is previewable")
+        -- Determine if we need zoom (for expressions/moods, we want a closer view)
+        local needsZoom = (emoteType == EmoteType.EXPRESSIONS)
+
+        -- Check if we're already showing this exact emote - if so, do nothing
+        if LastEmote.name == emoteName and hasClonedPed() then
+            return
+        end
+
+        -- If zoom state changed, we need to recreate the ped
+        if hasClonedPed() and currentZoomState ~= needsZoom then
+            ClosePedMenu()
+        end
+
+        -- Clear previous preview (ClearPedTaskPreview uses LastEmote to know what to clear)
+        if hasClonedPed() then
+            ClearPedTaskPreview()
+        end
+
+        -- Update LastEmote to new preview
+        LastEmote = {
+            name = emoteName,
+            emoteType = emoteType,
+        }
+
+        -- Show this emote
+        if hasClonedPed() then
+            -- Ped exists, just switch animation
+            EmoteMenuStartClone(emoteName, emoteType)
+        else
+            -- Ped doesn't exist, create it with appropriate zoom
+            currentZoomState = needsZoom
+            ShowPedMenu(needsZoom)
+            WaitForClonedPedThenPlayLastAnim()
+        end
+    else
+        hidePreview()
+    end
+    return true
+end
+
 --- Unified handler that updates CurrentMenuSelection, instruction buttons, and ped preview
 --- Called whenever menu selection changes (scroll, menu open, menu close)
 ---@param currentMenu table The menu to check for preview
@@ -347,45 +392,7 @@ local function onMenuItemHover(currentMenu)
     local emote = EmoteData[emoteName] or SharedEmoteData[emoteName]
 
     -- Check if the selected item is a previewable emote
-   -- Check if the selected item is a previewable emote
-    if emoteType == EmoteType.EXPRESSIONS or (emote and isEmoteTypePreviewable(emote.emoteType)) then
-        -- Determine if we need zoom (for expressions/moods, we want a closer view)
-        local needsZoom = (emoteType == EmoteType.EXPRESSIONS)
-
-        -- Check if we're already showing this exact emote - if so, do nothing
-        if LastEmote.name == emoteName and hasClonedPed() then
-            return
-        end
-
-        -- If zoom state changed, we need to recreate the ped
-        if hasClonedPed() and currentZoomState ~= needsZoom then
-            ClosePedMenu()
-        end
-
-        -- Clear previous preview (ClearPedTaskPreview uses LastEmote to know what to clear)
-        if hasClonedPed() then
-            ClearPedTaskPreview()
-        end
-
-        -- Update LastEmote to new preview
-        LastEmote = {
-            name = emoteName,
-            emoteType = emoteType,
-        }
-
-        -- Show this emote
-        if hasClonedPed() then
-            -- Ped exists, just switch animation
-            EmoteMenuStartClone(emoteName, emoteType)
-        else
-            -- Ped doesn't exist, create it with appropriate zoom
-            currentZoomState = needsZoom
-            ShowPedMenu(needsZoom)
-            WaitForClonedPedThenPlayLastAnim()
-        end
-    else
-        hidePreview()
-    end
+    CreatePreviewPed(emoteName, emoteType)
 end
 
 ---@param parent SubMenu|table

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -446,18 +446,24 @@ local function addKeybindMenu(parent)
         createSubMenu(parent, "keybinds", Translate("keybinds"))
     end
     local menu = subMenus["keybinds"]
+    local bindsForNUI = {}
 
     for id = 1, #Config.KeybindKeys do
-        local emoteData = GetResourceKvpString(string.format('%s_bind_%s', Config.keybindKVP, id))
+        local bindKVP = string.format('%s_bind_%s', Config.keybindKVP, id)
+        local emoteData = GetResourceKvpString(bindKVP)
         if emoteData and emoteData ~= "" then
             emoteData = json.decode(emoteData)
         end
-        local label = string.format("Slot %i: ~b~%s~s~ %s", id, (emoteData and EmoteTypeEmoji[emoteData.emoteType]) or "", (emoteData and emoteData.label) or "Empty Slot")
-        local description = string.format("This slot is bound to [ ~b~%s~s~ ]. You can change this in the in-game settings.", GetKeyForCommand("emoteSelect"..id))
+        local keyLabel = GetKeyForCommand("emoteSelect"..id)
+        local label = string.format("Slot %i: ~b~%s~s~ %s", id, (emoteData and EmoteTypeEmoji[emoteData.emoteType]) or "", (emoteData and emoteData.label) or Translate("empty_slot"))
+        local description = string.format("This slot is bound to [ ~b~%s~s~ ]. You can change this in the in-game settings.", keyLabel)
         local item = NativeUI.CreateItem(label, description)
+        bindsForNUI[bindKVP] = {id = id, emoteType = (emoteData and emoteData.emoteType) or "", emoteName = (emoteData and emoteData.emoteName) or "", emoteLabel = (emoteData and emoteData.label) or "", keyLabel = keyLabel, bindKVP = bindKVP}
         menu.menu:AddItem(item)
         menu.items[#menu.items+1] = {name = "slot_"..id}
     end
+
+    TriggerEvent("rpemotes:internal:sendKeybindsDataToNUI", bindsForNUI)
 
     menu.menu.OnItemSelect = function(_, item, index)
         if dataForKeybind.emoteName then

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -1,9 +1,11 @@
 local nuiReady = false
 
 
-
+-- The NUI logic is designed to run *on top* of the existing NativeUI logic, since that menu already does all the data handling that we need.
 -- As the NativeUI menu is being built, this data will be built as well. When we send this to NUI, we will clear it from Lua to get some bytes back.
--- NativeUI kinda wants to rebuild the menu a lot, so let's be careful here.
+-- In my opinion, this is a better way to maintain both menu styles, as any new logic that will be added to the emotes data, will reflect in both menus. -CritteR
+
+
 local dataForMenu = {
     type = "BUILD_EMOTE_MENUS",
     ["emotes"] = {},
@@ -13,8 +15,7 @@ local dataForMenu = {
     ["walkstyles"] = {},
     ["moods"] = {},
     ["emojis"] = {},
-    ["favorites"] = {},
-    ["keybinds"] = {}
+    ["favorites"] = {}
 }
 
 local NUIEmoteType = {
@@ -28,13 +29,6 @@ local NUIEmoteType = {
     ["PropEmotes"] = "propemotes",
     ["Emojis"] = "emojis"
 }
-
-
-RegisterCommand("__nui", function()
-    print(not IsNuiFocused())
-    SetNuiFocus(not IsNuiFocused(), not IsNuiFocused())
-    SetNuiFocusKeepInput(true)
-end)
 
 RegisterNUICallback('NUI_READY', function(data, cb)
     nuiReady = true
@@ -67,12 +61,12 @@ RegisterNUICallback('ROUTE_EMOTE', function(data, cb)
     if data.type == "emote" then
         RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
     elseif data.type == "groupemote" then
-        ToggleNUIMenu()
+        ToggleNUIMenu() -- Important to close first. Group emote request blocks the thread until you actually start the request.
         OnGroupEmoteRequest(data.emoteName)
     elseif data.type == "placement" then
         if Config.PlacementEnabled then
-            ToggleNUIMenu()
             StartNewPlacement(data.emoteName)
+            ToggleNUIMenu() -- Important to close *after* the placement request. Closing it before the request will block the preview ped on the screen.
         end
     end
 
@@ -89,9 +83,34 @@ RegisterNUICallback("FAVORITE_EMOTE", function(data, cb)
             textureVariation = 1
         }
         ToggleFavoriteEmote(emoteData.id, emoteData)
+        local favData = GetFavoriteEmotes()
+        local favMap = GetFavoriteEmotesMap()
+        local favorites = {}
+        for index, emoteId in pairs(favMap) do
+            favorites[index] = favData[emoteId]
+        end
+        cb({["favorites"] = favorites})
+        return
     end
     cb({["ok"] = true})
 end)
+
+RegisterNUICallback('KEYBIND_EMOTE', function(data, cb)
+    if data.type == "set" then
+        if data.emoteName and data.emoteType and data.emoteLabel and data.id then
+            EmoteBindStart({data.id, data.emoteName, data.emoteLabel, data.emoteType})
+            RebuildEmoteMenu()
+        end
+    elseif data.type == "clear" then
+        if data.id then
+            DeleteEmoteBind({data.id})
+            RebuildEmoteMenu()
+        end
+    end
+
+    cb({["ok"] = true})
+end)
+
 
 RegisterNUICallback('PREVIEW_EMOTE', function(data, cb)
     local returnValue = true
@@ -112,7 +131,6 @@ RegisterNUICallback('PLAY_SOUND_FRONTEND', function(data, cb)
 end)
 
 RegisterNUICallback('GET_LOCALES', function(data, cb)
-    print(Locales[Config.MenuLanguage])
     cb({["ok"] = true, ["data"] = Locales[Config.MenuLanguage]})
 end)
 
@@ -147,9 +165,17 @@ AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
         ["walkStyles"] = {},
         ["moods"] = {},
         ["emojis"] = {},
-        ["favorites"] = {},
-        ["keybinds"] = {}
+        ["favorites"] = {}
     }
+end)
+
+AddEventHandler("rpemotes:internal:sendKeybindsDataToNUI", function(binds)
+    while not nuiReady do Citizen.Wait(10) end
+
+    SendNUIMessage({
+        type = "BUILD_KEYBINDS_MENU",
+        ["keybinds"] = binds
+    })
 end)
 
 function ToggleNUIMenu() 
@@ -178,9 +204,9 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             DisableControlAction(0,24,true)
             DisableControlAction(0,25,true)
         else
-            -- SetCursorLocation(0.5,0.5)
+            -- SetCursorLocation(0.5,0.5) -- Used to block the cursor while the player is not using it.
             -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
-            -- Keep this out for now, since it controls the OS cursor too :),
+            -- This means that it controls the OS cursor too :),
             -- meaning that you can hijack a player's cursor, even if the game is not focused :)
         end
         if IsControlJustReleased(0,19) then

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -9,9 +9,7 @@ local nuiReady = false
 local dataForMenu = {
     type = "BUILD_EMOTE_MENUS",
     ["emotes"] = {},
-    ["sharedemotes"] = {},
-    ["propemotes"] = {},
-    ["danceemotes"] = {},
+    -- ["Custom Category Name"] = {} -- Automagically added by the builder.
     ["walkstyles"] = {},
     ["moods"] = {},
     ["emojis"] = {},
@@ -28,6 +26,35 @@ local NUIEmoteType = {
     [EmoteType.EMOTES] = "emotes",
     [EmoteType.PROP_EMOTES] = "propemotes",
     [EmoteType.EMOJI] = "emojis"
+}
+
+local function getEmojiFromCategoryName(str)
+    -- Wild for-loop to find emojis in the string.
+    for i, char in utf8.codes(str) do
+        if (
+            (char >= 0x1F600 and char <= 0x1F64F)  -- Emoticons
+            or (char >= 0x1F300 and char <= 0x1F5FF)  -- Misc Symbols
+            or (char >= 0x1F680 and char <= 0x1F6FF)  -- Transport/Map
+            or (char >= 0x2600 and char <= 0x26FF)    -- Misc Symbols
+            or (char >= 0x2700 and char <= 0x27BF)    -- Dingbats
+            or (char >= 0x1F900 and char <= 0x1F9FF)  -- Supplemental
+            or (char >= 0x1FA70 and char <= 0x1FAFF)  -- Extended-A
+        ) then
+            return utf8.char(char)
+        end
+    end
+    local NUIEmoteCategoryEmoji = {"🚵", "🥳", "💃", "🤸", "🤹‍♂️", "🤹‍♀️", "🤓", "🏄‍♂️", "⛹️‍♀️", "🏋️"} -- If we cannot find an emoji in the category name, use a random one from here.
+    return NUIEmoteCategoryEmoji[math.random(1, #NUIEmoteCategoryEmoji)]
+end
+
+local function getHtmlClassFromCategoryName(str)
+    local toLower = str:lower()
+    local result = toLower:gsub("[%s%p]", "")
+    return result
+end
+
+local NUIEmoteCategories = {
+    -- ["Custom Category Name"] = {id="new-category-name", icon = "🥳"}
 }
 
 RegisterNUICallback('NUI_READY', function(data, cb)
@@ -136,18 +163,26 @@ end)
 
 
 AddEventHandler("rpemotes:internal:loadEmoteDataToNUI", function(EmoteData, CategoryToEmotes)
-    while not nuiReady do Citizen.Wait(10) end
+    for name, emotes in pairs(CategoryToEmotes) do
+        local htmlClass = getHtmlClassFromCategoryName(name)
+        NUIEmoteCategories[name] = {id=htmlClass, icon = getEmojiFromCategoryName(name)}
+        dataForMenu[htmlClass] = {}
+    end
 
-    SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes, emoteTypeIcons = EmoteTypeEmoji})
+
+    while not nuiReady do Citizen.Wait(10) end
+    SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes, emoteCategories = NUIEmoteCategories, emoteTypeIcons = EmoteTypeEmoji})
 end)
 
 function AddEmoteToNUIQueue(data)
+    -- data = {emoteName, emoteType, label, categoryName, hasPermission, isFavorite}
     if data.isFavorite then
         table.insert(dataForMenu["favorites"], data)
         return
     end
-    if dataForMenu[NUIEmoteType[data.emoteType]] ~= nil then
-        table.insert(dataForMenu[NUIEmoteType[data.emoteType]], data)  
+    local tbl = dataForMenu[NUIEmoteCategories[data.categoryName] and NUIEmoteCategories[data.categoryName].id] or dataForMenu[NUIEmoteType[data.emoteType]]
+    if tbl ~= nil then
+        table.insert(tbl, data)
     end
 end
 

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -142,7 +142,6 @@ AddEventHandler("rpemotes:internal:loadEmoteDataToNUI", function(EmoteData, Cate
 end)
 
 function AddEmoteToNUIQueue(data)
-    -- data = {}
     if data.isFavorite then
         table.insert(dataForMenu["favorites"], data)
         return
@@ -156,7 +155,7 @@ AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
     while not nuiReady do Citizen.Wait(10) end
 
     SendNUIMessage(dataForMenu)
-    dataForMenu = { -- Restarting it.
+    dataForMenu = {
         type = "BUILD_EMOTE_MENUS",
         ["emotes"] = {},
         ["sharedEmotes"] = {},
@@ -204,7 +203,7 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             DisableControlAction(0,24,true)
             DisableControlAction(0,25,true)
         else
-            -- SetCursorLocation(0.5,0.5) -- Used to block the cursor while the player is not using it.
+            SetCursorLocation(0.5,0.5) -- Used to block the cursor while the player is not using it.
             -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
             -- This means that it controls the OS cursor too :),
             -- meaning that you can hijack a player's cursor, even if the game is not focused :)
@@ -212,7 +211,7 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
         if IsControlJustReleased(0,19) then
             SetNuiFocus(true, false)
         end
-        Citizen.Wait(1) -- LOL
+        Citizen.Wait(1)
     end
     CreatePreviewPed("", "")
     SendNUIMessage({type = "OPEN_MENU", value = false})

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -189,11 +189,13 @@ end
 
 AddEventHandler("rpemotes:internal:handleNUIOpened", function()
     SendNUIMessage({type = "OPEN_MENU", value = true})
+    SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
     while IsNuiFocused() do
         DisableControlAction(0,37,true)
         DisableControlAction(0,200,true)
         if IsControlJustPressed(0,19) then
             SetNuiFocus(true, true)
+            SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = true})
         end
         if IsControlPressed(0,19) then
             DisableControlAction(0,1,true)
@@ -202,14 +204,10 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             DisableControlAction(0,15,true)
             DisableControlAction(0,24,true)
             DisableControlAction(0,25,true)
-        else
-            SetCursorLocation(0.5,0.5) -- Used to block the cursor while the player is not using it.
-            -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
-            -- This means that it controls the OS cursor too :),
-            -- meaning that you can hijack a player's cursor, even if the game is not focused :)
         end
         if IsControlJustReleased(0,19) then
             SetNuiFocus(true, false)
+            SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
         end
         Citizen.Wait(1)
     end

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -1,4 +1,150 @@
+local nuiReady = false
+
+
+
+-- As the NativeUI menu is being built, this data will be built as well. When we send this to NUI, we will clear it from Lua to get some bytes back.
+-- NativeUI kinda wants to rebuild the menu a lot, so let's be careful here.
+local dataForMenu = {
+    type = "BUILD_EMOTE_MENUS",
+    ["emotes"] = {},
+    ["sharedemotes"] = {},
+    ["propemotes"] = {},
+    ["danceemotes"] = {},
+    ["walkstyles"] = {},
+    ["moods"] = {},
+    ["emojis"] = {},
+    ["favorites"] = {},
+    ["keybinds"] = {}
+}
+
+local NUIEmoteType = {
+    ["Expressions"] = "moods",
+    ["Walks"] = "walkstyles",
+    ["Shared"] = "sharedemotes",
+    ["Dances"] = "danceemotes",
+    ["AnimalEmotes"] = "emotes",
+    ["Exits"] = "emotes",
+    ["Emotes"] = "emotes",
+    ["PropEmotes"] = "propemotes",
+    ["Emojis"] = "emojis"
+}
+
+
 RegisterCommand("__nui", function()
-    print("HIII")
+    print(not IsNuiFocused())
     SetNuiFocus(not IsNuiFocused(), not IsNuiFocused())
+    SetNuiFocusKeepInput(true)
+end)
+
+RegisterNUICallback('NUI_READY', function(data, cb)
+    nuiReady = true
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('CLOSE_MENU', function(data, cb)
+    ToggleNUIMenu()
+    print("Close menu")
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('SEARCH_BAR_FOCUS', function(data, cb)
+    if data.isFocused then
+        SetNuiFocusKeepInput(false)
+    else
+        SetNuiFocusKeepInput(true)
+    end
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('CANCEL_EMOTE', function(data, cb)
+    EmoteCancel()
+    DestroyAllProps()
+
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('ROUTE_EMOTE', function(data, cb)
+    RouteEmoteToFunction(data.emoteName, data.emoteType, 0)
+
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('GET_LOCALES', function(data, cb)
+    print(Locales[Config.MenuLanguage])
+    cb({["ok"] = true, ["data"] = Locales[Config.MenuLanguage]})
+end)
+
+
+AddEventHandler("rpemotes:internal:loadEmoteDataToNUI", function(EmoteData, CategoryToEmotes)
+    while not nuiReady do Citizen.Wait(10) end
+
+    SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes})
+end)
+
+function AddEmoteToNUIQueue(data)
+    -- data = {}
+    if data.isFavorite then
+        table.insert(dataForMenu["favorites"], data)
+        return
+    end
+    if dataForMenu[NUIEmoteType[data.emoteType]] ~= nil then
+        table.insert(dataForMenu[NUIEmoteType[data.emoteType]], data)  
+    end
+end
+
+AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
+    while not nuiReady do Citizen.Wait(10) end
+
+    SendNUIMessage(dataForMenu)
+    dataForMenu = { -- Restarting it.
+        type = "BUILD_EMOTE_MENUS",
+        ["emotes"] = {},
+        ["sharedEmotes"] = {},
+        ["propEmotes"] = {},
+        ["danceEmotes"] = {},
+        ["walkStyles"] = {},
+        ["moods"] = {},
+        ["emojis"] = {},
+        ["favorites"] = {},
+        ["keybinds"] = {}
+    }
+end)
+
+function ToggleNUIMenu() 
+    if not IsNuiFocused() then
+        SetNuiFocus(true, false)
+        SetNuiFocusKeepInput(true)
+        TriggerEvent("rpemotes:internal:handleNUIOpened")
+    else
+        SetNuiFocus(false, false)
+    end
+end
+
+AddEventHandler("rpemotes:internal:handleNUIOpened", function()
+    SendNUIMessage({type = "OPEN_MENU", value = true})
+    while IsNuiFocused() do
+        DisableControlAction(0,37,true)
+        DisableControlAction(0,200,true)
+        if IsControlJustPressed(0,19) then
+            SetNuiFocus(true, true)
+        end
+        if IsControlPressed(0,19) then
+            DisableControlAction(0,1,true)
+            DisableControlAction(0,2,true)
+            DisableControlAction(0,14,true)
+            DisableControlAction(0,15,true)
+            DisableControlAction(0,24,true)
+            DisableControlAction(0,25,true)
+        else
+            -- SetCursorLocation(0.5,0.5)
+            -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
+            -- Keep this out for now, since it controls the OS cursor too :),
+            -- meaning that you can hijack a player's cursor, even if the game is not focused :)
+        end
+        if IsControlJustReleased(0,19) then
+            SetNuiFocus(true, false)
+        end
+        Citizen.Wait(1) -- LOL
+    end
+    SendNUIMessage({type = "OPEN_MENU", value = false})
 end)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -43,7 +43,7 @@ end)
 
 RegisterNUICallback('CLOSE_MENU', function(data, cb)
     ToggleNUIMenu()
-    print("Close menu")
+    PlaySoundFrontend(-1, "QUIT", "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
     cb({["ok"] = true})
 end)
 
@@ -64,7 +64,25 @@ RegisterNUICallback('CANCEL_EMOTE', function(data, cb)
 end)
 
 RegisterNUICallback('ROUTE_EMOTE', function(data, cb)
-    RouteEmoteToFunction(data.emoteName, data.emoteType, 0)
+    RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
+
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('PREVIEW_EMOTE', function(data, cb)
+    local returnValue = true
+    if data.emoteName and data.emoteType then
+        returnValue = CreatePreviewPed(data.emoteName, data.emoteType)
+    else
+        CreatePreviewPed("", "")
+    end
+
+    cb({["ok"] = true, ["done"] = returnValue})
+end)
+
+
+RegisterNUICallback('PLAY_SOUND_FRONTEND', function(data, cb)
+    PlaySoundFrontend(-1, data.soundName, "HUD_FRONTEND_DEFAULT_SOUNDSET", true)
 
     cb({["ok"] = true})
 end)
@@ -136,7 +154,7 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             DisableControlAction(0,24,true)
             DisableControlAction(0,25,true)
         else
-            -- SetCursorLocation(0.5,0.5)
+            SetCursorLocation(0.5,0.5)
             -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
             -- Keep this out for now, since it controls the OS cursor too :),
             -- meaning that you can hijack a player's cursor, even if the game is not focused :)
@@ -146,5 +164,6 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
         end
         Citizen.Wait(1) -- LOL
     end
+    CreatePreviewPed("", "")
     SendNUIMessage({type = "OPEN_MENU", value = false})
 end)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -19,15 +19,15 @@ local dataForMenu = {
 }
 
 local NUIEmoteType = {
-    ["Expressions"] = "moods",
-    ["Walks"] = "walkstyles",
-    ["Shared"] = "sharedemotes",
-    ["Dances"] = "danceemotes",
-    ["AnimalEmotes"] = "emotes",
-    ["Exits"] = "emotes",
-    ["Emotes"] = "emotes",
-    ["PropEmotes"] = "propemotes",
-    ["Emojis"] = "emojis"
+    [EmoteType.EXPRESSIONS] = "moods",
+    [EmoteType.WALKS] = "walkstyles",
+    [EmoteType.SHARED] = "sharedemotes",
+    [EmoteType.DANCES] = "danceemotes",
+    [EmoteType.ANIMAL_EMOTES] = "emotes",
+    [EmoteType.EXITS] = "emotes",
+    [EmoteType.EMOTES] = "emotes",
+    [EmoteType.PROP_EMOTES] = "propemotes",
+    [EmoteType.EMOJI] = "emojis"
 }
 
 RegisterNUICallback('NUI_READY', function(data, cb)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -1,0 +1,4 @@
+RegisterCommand("__nui", function()
+    print("HIII")
+    SetNuiFocus(not IsNuiFocused(), not IsNuiFocused())
+end)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -64,8 +64,32 @@ RegisterNUICallback('CANCEL_EMOTE', function(data, cb)
 end)
 
 RegisterNUICallback('ROUTE_EMOTE', function(data, cb)
-    RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
+    if data.type == "emote" then
+        RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
+    elseif data.type == "groupemote" then
+        ToggleNUIMenu()
+        OnGroupEmoteRequest(data.emoteName)
+    elseif data.type == "placement" then
+        if Config.PlacementEnabled then
+            ToggleNUIMenu()
+            StartNewPlacement(data.emoteName)
+        end
+    end
 
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback("FAVORITE_EMOTE", function(data, cb)
+    if data.emoteName and data.emoteType and data.emoteLabel then
+        local emoteData = {
+            id = data.emoteType.."_"..data.emoteName,
+            name = data.emoteName,
+            emoteType = data.emoteType,
+            label = data.emoteLabel or data.emoteName,
+            textureVariation = 1
+        }
+        ToggleFavoriteEmote(emoteData.id, emoteData)
+    end
     cb({["ok"] = true})
 end)
 
@@ -96,7 +120,7 @@ end)
 AddEventHandler("rpemotes:internal:loadEmoteDataToNUI", function(EmoteData, CategoryToEmotes)
     while not nuiReady do Citizen.Wait(10) end
 
-    SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes})
+    SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes, emoteTypeIcons = EmoteTypeEmoji})
 end)
 
 function AddEmoteToNUIQueue(data)
@@ -154,7 +178,7 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             DisableControlAction(0,24,true)
             DisableControlAction(0,25,true)
         else
-            SetCursorLocation(0.5,0.5)
+            -- SetCursorLocation(0.5,0.5)
             -- Even if you don't give the cursor to NUI, the menu still picks it up because it's focused...
             -- Keep this out for now, since it controls the OS cursor too :),
             -- meaning that you can hijack a player's cursor, even if the game is not focused :)

--- a/client/NUI/css/dynamic.css
+++ b/client/NUI/css/dynamic.css
@@ -1,0 +1,23 @@
+@media (max-width: 1367px) {
+	html {
+		font-size: 50%;
+	}
+}
+
+@media (max-width: 1281px) {
+	html {
+		font-size: 46%;
+	}
+}
+
+@media (max-width: 1100px) {
+	html {
+		font-size: 43.7%;
+	}
+}
+
+@media (max-width: 900px) {
+	html {
+		font-size: 40%;
+	}
+}

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -9,18 +9,22 @@
 :root {
     --color-bg-primary: #2e2e2e;
     --color-bg-sidebar: #111111;
+
     --color-text-primary: #efefef;
     --color-text-secondary: #8a8a8a;
 
-    --color-btn-bg: rgb(62, 62, 62);
-    --color-btn-border: rgb(29, 29, 29);
-    --color-btn-hover: rgb(79, 79, 79);
-    --color-accent-primary: rgb(21, 137, 216);
-    --color-accent-primary-hover: rgb(59, 173, 248);
-    --color-accent-secondary: rgb(216, 76, 21);
-    --color-accent-secondary-hover: rgb(255, 130, 81);
-    --color-btn-accent-favorite: gold;
-    --color-btn-accent-favorite-hover: rgb(255, 233, 108);
+    --color-border: #8a8a8a;
+    --color-border-accent-primary: #1589d8;
+
+    --color-btn-bg: #3e3e3e;
+    --color-btn-border: #1d1d1d;
+    --color-btn-hover: #4f4f4f;
+    --color-accent-primary: #1589d8;
+    --color-accent-primary-hover: #3badf8;
+    --color-accent-secondary: #d84c15;
+    --color-accent-secondary-hover: #ff8251;
+    --color-accent-favorite: #ffd700;
+    --color-accent-favorite-hover: #ffe96c;
 
     --font-size-primary: 1.6rem;
 }
@@ -75,8 +79,8 @@ html {
 
 .noto-color-emoji-regular {
   font-family: "Noto Color Emoji", sans-serif;
-  font-weight: 400;
-  font-style: normal;
+  font-weight: normal !important;
+  font-style: normal !important;
 }
 
 body {
@@ -91,7 +95,7 @@ body {
 }
 
 hr {
-    border-color: var(--color-btn-bg);
+    border-color: var(--color-border);
     margin: 0.4rem 0;
 }
 
@@ -248,17 +252,15 @@ hr {
 }
 
 .btn-emote-favorite {
-    background: linear-gradient(to left, var(--color-btn-accent-favorite) -100%, var(--color-btn-bg));
+    background: linear-gradient(to left, var(--color-accent-favorite) -100%, var(--color-btn-bg));
 }
 
 .btn-emote-favorite:hover, .btn-emote-favorite:focus-visible {
-    background: linear-gradient(to left, var(--color-btn-accent-favorite-hover) -100%, var(--color-btn-hover));
+    background: linear-gradient(to left, var(--color-accent-favorite-hover) -100%, var(--color-btn-hover));
 }
 
 
 /* KEYBINDS */
-
-.keybind-1-bind {}
 
 .keybinds-list {
     display: flex;
@@ -273,7 +275,7 @@ hr {
     flex-direction: column;
     gap: 1rem;
     padding: 1rem 2rem;
-    border: 1px solid var(--color-btn-bg);
+    border: 1px solid var(--color-border);
     border-radius: 1.5rem;
 }
 
@@ -294,7 +296,7 @@ hr {
 
 
 
-/* Context Popover */
+/* POPOVER */
 
 .popover {
     position: fixed;

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -1,0 +1,213 @@
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+
+:root {
+    --color-bg-main: #2e2e2e;
+    --colog-bg-sidebar: #111111;
+    --color-text-main: #efefef;
+    --color-text-secondary: #8a8a8a;
+
+    --color-btn-bg: #3e3e3e;
+    --color-btn-border: #1d1d1d;
+    --color-btn-hover: #4f4f4f;
+    --color-btn-active: rgb(21, 137, 216);
+
+    --font-size-main: 1.6rem;
+}
+
+
+img,
+.noselect {
+	user-select: none;
+}
+
+/* FiveM's CEF doesn't support standard CSS scrollbar styling :D */
+.invisible-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.grid {
+    display: grid;
+    width: 100%;
+}
+
+.singlecolumn {
+    grid-template-columns: 1fr;
+    row-gap: 0.5rem;
+    column-gap: 0.5rem;
+}
+
+.doublecolumn {
+    grid-template-columns: 1fr 1fr;
+    row-gap: 0.5rem;
+    column-gap: 0.5rem;
+}
+
+.triplecolumn {
+    grid-template-columns: 1fr 1fr 1fr;
+    row-gap: 0.5rem;
+    column-gap: 0.5rem;
+}
+
+/* This makes 1rem = 10px (more-or-less). We will also use this to scale lower resolutions. */
+html {
+	font-size: 62.5%; 
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 0 3rem;
+    height: 100vh;
+
+    font-size: var(--font-size-main);
+}
+
+.main-container {
+    display: flex;
+    width: 42rem;
+    flex-direction: column;
+    background-color: var(--color-bg-main);
+    color: var(--color-text-main);
+    height: 60vh;
+    overflow: auto;
+    border-radius: 1rem;
+}
+
+.header-container {
+    display: flex; /* Removes some weird margin-bottom in block display */
+}
+
+.header-image {
+    width: 100%;
+    height: auto;
+}
+
+.search-container {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+}
+
+.search-input {
+    flex-grow: 1;
+    height: 3.2rem;
+    background-color: var(--color-btn-bg);
+    color: var(--color-text-main);
+    border: none;
+    border-radius: 1rem;
+    padding: 0 1rem;
+}
+
+.btn-clear-search {
+    width: 3.2rem;
+    height: 3.2rem;
+    border: none !important;
+    border-radius: 100% !important;
+}
+
+.menu-container {
+    position: relative;
+    display: flex;
+    overflow-x: hidden;
+    flex-grow: 1;
+    gap: 1rem;
+}
+
+.side-navigation {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: auto;
+    height: 100%;
+    max-width: 5.2rem;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: none;
+    background-color: var(--colog-bg-sidebar);
+    transition: all 200ms;
+    flex-wrap: nowrap;
+}
+
+.side-navigation:hover {
+    max-width: 80%;
+    flex-grow: 1;
+}
+
+.btn {
+    display: inline-block;
+    background-color: var(--color-btn-bg);
+    color: var(--color-text-main);
+    border: none;
+    border-radius: 25%;
+    transition: all 200ms;
+}
+
+.btn:hover {
+    background-color: var(--color-btn-hover);
+}
+
+.sidebar-button-container {
+    overflow: hidden;
+    width: 100%;
+    text-wrap: nowrap;
+}
+
+.sidebar-button-active button {
+    background-color: var(--color-btn-active);
+}
+.sidebar-button-active span {
+    color: var(--color-btn-active);
+}
+
+.btn-sidebar {
+    width: 4.2rem;
+    height: 4.2rem;
+    margin: 0.5rem 0.5rem;
+}
+
+.btn-sidebar-label {
+    display: none;
+    text-wrap: nowrap;
+    margin-right: 3rem;
+}
+
+.side-navigation:hover .btn-sidebar-label {
+    display: inline;
+    text-wrap: nowrap;
+}
+
+.content-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin-left: 5.4rem;
+    padding: 1rem;
+    flex-grow: 1;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: none;
+}
+
+.footer-container {
+    padding: 0.2rem 1rem;
+    text-align: center;
+    border-top: 1px solid var(--colog-bg-sidebar);
+    color: var(--color-text-secondary);
+}
+
+
+/* ------------------- */
+
+.btn-emote {
+    height: 3.6rem;
+    border-radius: 1rem;
+}

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -6,17 +6,22 @@
 
 
 :root {
-    --color-bg-main: #2e2e2e;
-    --colog-bg-sidebar: #111111;
-    --color-text-main: #efefef;
+    --color-bg-primary: #2e2e2e;
+    --color-bg-sidebar: #111111;
+    --color-text-primary: #efefef;
     --color-text-secondary: #8a8a8a;
 
     --color-btn-bg: #3e3e3e;
     --color-btn-border: #1d1d1d;
     --color-btn-hover: #4f4f4f;
-    --color-btn-active: rgb(21, 137, 216);
+    --color-accent-primary: rgb(21, 137, 216);
+    --color-accent-primary-hover: rgb(59, 173, 248);
+    --color-accent-secondary: rgb(216, 76, 21);
+    --color-accent-secondary-hover: rgb(255, 130, 81);
+    --color-btn-accent-favorite: gold;
+    --color-btn-accent-favorite-hover: rgb(255, 233, 108);
 
-    --font-size-main: 1.6rem;
+    --font-size-primary: 1.6rem;
 }
 
 
@@ -30,9 +35,13 @@ img,
   display: none;
 }
 
-.grid {
-    display: grid;
+.menu {
+    display: none;
     width: 100%;
+}
+
+.grid {
+    display: grid !important;
 }
 
 .singlecolumn {
@@ -55,7 +64,7 @@ img,
 
 /* This makes 1rem = 10px (more-or-less). We will also use this to scale lower resolutions. */
 html {
-	font-size: 62.5%; 
+	font-size: 62.5%;
 }
 
 body {
@@ -66,15 +75,20 @@ body {
     padding: 0 3rem;
     height: 100vh;
 
-    font-size: var(--font-size-main);
+    font-size: var(--font-size-primary);
+}
+
+hr {
+    border-color: var(--color-btn-bg);
+    margin: 0.4rem 0;
 }
 
 .main-container {
     display: flex;
     width: 42rem;
     flex-direction: column;
-    background-color: var(--color-bg-main);
-    color: var(--color-text-main);
+    background-color: var(--color-bg-primary);
+    color: var(--color-text-primary);
     height: 60vh;
     overflow: auto;
     border-radius: 1rem;
@@ -99,7 +113,7 @@ body {
     flex-grow: 1;
     height: 3.2rem;
     background-color: var(--color-btn-bg);
-    color: var(--color-text-main);
+    color: var(--color-text-primary);
     border: none;
     border-radius: 1rem;
     padding: 0 1rem;
@@ -131,12 +145,12 @@ body {
     overflow-x: hidden;
     overflow-y: auto;
     scrollbar-width: none;
-    background-color: var(--colog-bg-sidebar);
+    background-color: var(--color-bg-sidebar);
     transition: all 200ms;
     flex-wrap: nowrap;
 }
 
-.side-navigation:hover {
+.side-navigation:hover, .side-navigation:has(button:focus-visible) {
     max-width: 80%;
     flex-grow: 1;
 }
@@ -144,7 +158,7 @@ body {
 .btn {
     display: inline-block;
     background-color: var(--color-btn-bg);
-    color: var(--color-text-main);
+    color: var(--color-text-primary);
     border: none;
     border-radius: 25%;
     transition: all 200ms;
@@ -154,17 +168,26 @@ body {
     background-color: var(--color-btn-hover);
 }
 
+/* I had to fight with this POS to work correctly in FiveM CEF. */
 .sidebar-button-container {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
     overflow: hidden;
     width: 100%;
+    min-width: 20rem; /* mandatory... */
     text-wrap: nowrap;
+    flex-wrap: nowrap;
 }
 
 .sidebar-button-active button {
-    background-color: var(--color-btn-active);
+    background-color: var(--color-accent-primary);
+}
+.sidebar-button-active button:hover {
+    background-color: var(--color-accent-primary-hover);
 }
 .sidebar-button-active span {
-    color: var(--color-btn-active);
+    color: var(--color-accent-primary);
 }
 
 .btn-sidebar {
@@ -179,7 +202,7 @@ body {
     margin-right: 3rem;
 }
 
-.side-navigation:hover .btn-sidebar-label {
+.side-navigation:hover .btn-sidebar-label, .side-navigation:has(button:focus-visible) .btn-sidebar-label {
     display: inline;
     text-wrap: nowrap;
 }
@@ -200,14 +223,64 @@ body {
 .footer-container {
     padding: 0.2rem 1rem;
     text-align: center;
-    border-top: 1px solid var(--colog-bg-sidebar);
-    color: var(--color-text-secondary);
+    border-top: 1px solid var(--color-bg-sidebar);
+    color: var(--color-text-primary);
 }
 
 
 /* ------------------- */
 
-.btn-emote {
+.btn-emote, .btn-emoji {
     height: 3.6rem;
     border-radius: 1rem;
+}
+
+.btn-emote-favorite {
+    background: linear-gradient(to left, var(--color-btn-accent-favorite) -100%, var(--color-btn-bg));
+}
+
+.btn-emote-favorite:hover {
+    background: linear-gradient(to left, var(--color-btn-accent-favorite-hover) -100%, var(--color-btn-hover));
+}
+
+/* Context Popover */
+
+.popover {
+    position: fixed;
+    background-color: var(--color-btn-bg);
+    border: 1px solid var(--color-btn-border);
+    border-radius: 0.8rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    padding: 0.5rem 0;
+    z-index: 10000;
+    min-width: 15rem;
+    animation: popoverFadeIn 150ms ease-out;
+}
+
+@keyframes popoverFadeIn {
+    from {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+.popover-menu-item {
+    display: block;
+    width: 100%;
+    padding: 0.8rem 1rem;
+    background: none;
+    border: none;
+    color: var(--color-text-primary);
+    text-align: left;
+    cursor: pointer;
+    transition: all 200ms;
+}
+
+.popover-menu-item:hover {
+    background-color: var(--color-btn-hover);
+    color: var(--color-text-primary);
 }

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -53,6 +53,10 @@ img,
     display: none !important;
 }
 
+.no-cursor {
+    pointer-events: none !important;
+}
+
 .singlecolumn {
     grid-template-columns: 1fr;
     row-gap: 0.5rem;

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -7,16 +7,17 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap');
 
 :root {
-    --color-bg-primary: #2e2e2e;
-    --color-bg-sidebar: #111111;
+    --color-bg-primary: rgba(46, 46, 46, 1);
+    --color-bg-sidebar: rgba(17, 17, 17, 1);
 
-    --color-text-primary: #efefef;
-    --color-text-secondary: #8a8a8a;
+    --color-text-primary: rgba(239, 239, 239, 1);
+    --color-text-secondary: rgba(138, 138, 138, 1);
 
-    --color-border: #8a8a8a;
-    --color-border-accent-primary: #1589d8;
+    --color-border: rgba(138, 138, 138, 1);
+    --color-border-accent-primary: rgba(21, 137, 216, 1);
 
-    --color-btn-bg: #3e3e3e;
+    --color-btn-bg: rgba(62, 62, 62, 1);
+    --color-btn-popover-bg: rgba(62, 62, 62, 1);
     --color-btn-border: #1d1d1d;
     --color-btn-hover: #4f4f4f;
     --color-accent-primary: #1589d8;
@@ -329,7 +330,7 @@ hr {
     display: block;
     width: 100%;
     padding: 0.8rem 1rem;
-    background: none;
+    background-color: var(--color-btn-popover-bg);
     border: none;
     color: var(--color-text-primary);
     text-align: left;

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -12,9 +12,9 @@
     --color-text-primary: #efefef;
     --color-text-secondary: #8a8a8a;
 
-    --color-btn-bg: #3e3e3e;
-    --color-btn-border: #1d1d1d;
-    --color-btn-hover: #4f4f4f;
+    --color-btn-bg: rgb(62, 62, 62);
+    --color-btn-border: rgb(29, 29, 29);
+    --color-btn-hover: rgb(79, 79, 79);
     --color-accent-primary: rgb(21, 137, 216);
     --color-accent-primary-hover: rgb(59, 173, 248);
     --color-accent-secondary: rgb(216, 76, 21);
@@ -43,6 +43,10 @@ img,
 
 .grid {
     display: grid !important;
+}
+
+.hidden {
+    display: none !important;
 }
 
 .singlecolumn {
@@ -172,7 +176,7 @@ hr {
     transition: all 200ms;
 }
 
-.btn:hover {
+.btn:hover, .btn:focus-visible {
     background-color: var(--color-btn-hover);
 }
 
@@ -191,7 +195,7 @@ hr {
 .sidebar-button-active button {
     background-color: var(--color-accent-primary);
 }
-.sidebar-button-active button:hover {
+.sidebar-button-active button:hover, .sidebar-button-active button:focus-visible {
     background-color: var(--color-accent-primary-hover);
 }
 .sidebar-button-active span {
@@ -247,9 +251,48 @@ hr {
     background: linear-gradient(to left, var(--color-btn-accent-favorite) -100%, var(--color-btn-bg));
 }
 
-.btn-emote-favorite:hover {
+.btn-emote-favorite:hover, .btn-emote-favorite:focus-visible {
     background: linear-gradient(to left, var(--color-btn-accent-favorite-hover) -100%, var(--color-btn-hover));
 }
+
+
+/* KEYBINDS */
+
+.keybind-1-bind {}
+
+.keybinds-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+    flex-grow: 1;
+}
+
+.keybinds-list-item {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem 2rem;
+    border: 1px solid var(--color-btn-bg);
+    border-radius: 1.5rem;
+}
+
+.keybinds-item-buttons {
+    display: flex;
+    gap: 1rem;
+    width: 100%;
+}
+
+.btn-keybind {
+    flex-grow: 1;
+}
+
+.keybind-bind-text {
+    color: var(--color-accent-primary);
+    font-weight: 600;
+}
+
+
 
 /* Context Popover */
 
@@ -288,7 +331,7 @@ hr {
     transition: all 200ms;
 }
 
-.popover-menu-item:hover {
+.popover-menu-item:hover, .popover-menu-item:focus-visible {
     background-color: var(--color-btn-hover);
     color: var(--color-text-primary);
 }

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -4,6 +4,7 @@
 	box-sizing: border-box;
 }
 
+@import url('https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap');
 
 :root {
     --color-bg-primary: #2e2e2e;
@@ -65,6 +66,13 @@ img,
 /* This makes 1rem = 10px (more-or-less). We will also use this to scale lower resolutions. */
 html {
 	font-size: 62.5%;
+    font-family: 'Noto Color Emoji', 'Helvetica Neue', 'Segoe UI', Arial, sans-serif;
+}
+
+.noto-color-emoji-regular {
+  font-family: "Noto Color Emoji", sans-serif;
+  font-weight: 400;
+  font-style: normal;
 }
 
 body {

--- a/client/NUI/css/overrides.css
+++ b/client/NUI/css/overrides.css
@@ -1,0 +1,6 @@
+/* 
+
+This file is here for you to override CSS variables and properties, instead of changing the main and dynamic files,
+as those files might get changed at any moment with an update.
+
+*/

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -8,11 +8,12 @@
     <link rel="stylesheet" href="css/dynamic.css">
     <link rel="stylesheet" href="css/overrides.css">
 
+    <script type="module" src="js/utils.js" defer></script>
     <script type="module" src="js/classes.js" defer></script>
-    <script type="module" src="js/data.js" defer></script>
+    <script type="module" src="js/navigation.js" defer></script>
     <script type="module" src="js/main.js" defer></script>
 </head>
-<body>
+<body style="display: none;">
     <div class="main-container noselect">
         <header class="header-container">
             <img src="/header.png" alt="RP Emotes" class="header-image">
@@ -22,78 +23,86 @@
                 <ul>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
-                        <span class="btn-sidebar-label">Cancel Emote</span>
+                        <span class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</span>
                     </li>
                     <hr />
-                    <li class="sidebar-button-container">
+                    <li class="sidebar-button-container sidebar-button-active">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
-                        <span class="btn-sidebar-label">Emotes</span>
+                        <span class="btn-sidebar-label" data-locale="emotes">Emotes</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="sharedemotes-menu">👫</button>
-                        <span class="btn-sidebar-label">Shared Emotes</span>
+                        <span class="btn-sidebar-label" data-locale="shareemotes">Shared Emotes</span>
                     </li>
-                    <li class="sidebar-button-container sidebar-button-active">
-                        <button class="btn btn-sidebar btn-active" data-action="openMenu" data-menu="propemotes-menu">📦</button>
-                        <span class="btn-sidebar-label">Prop Emotes</span>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="propemotes-menu">📦</button>
+                        <span class="btn-sidebar-label" data-locale="propemotes">Prop Emotes</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="danceemotes-menu">🕺</button>
-                        <span class="btn-sidebar-label">Dance Emotes</span>
+                        <span class="btn-sidebar-label" data-locale="danceemotes">Dance Emotes</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="keybinds-menu">🔢</button>
-                        <span class="btn-sidebar-label">Keybinds</span>
+                        <span class="btn-sidebar-label" data-locale="keybinds">Keybinds</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="favorites-menu">🌟</button>
-                        <span class="btn-sidebar-label">Favorites</span>
+                        <span class="btn-sidebar-label" data-locale="favorites">Favorites</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="walkstyles-menu">🚶🏻‍♂️</button>
-                        <span class="btn-sidebar-label">Walk Styles</span>
+                        <span class="btn-sidebar-label" data-locale="walkstyles">Walk Styles</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="moods-menu">🎭</button>
-                        <span class="btn-sidebar-label">Moods</span>
+                        <span class="btn-sidebar-label" data-locale="moods">Moods</span>
                     </li>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="emojis-menu">😀</button>
-                        <span class="btn-sidebar-label">Emojis</span>
+                        <span class="btn-sidebar-label" data-locale="emojis">Emojis</span>
                     </li>
                 </ul>
             </nav>
             <section class="content-container invisible-scrollbar">
                 <form class="search-container">
-                    <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search [EMOTE_MENU_NAME]...">
+                    <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search..." data-locale="searchemotes">
                     <input type="reset" value="x" class="btn btn-clear-search"></input>
                 </form>
-                <article class="emotes-menu grid singlecolumn">
+                <article class="menu emotes-menu grid doublecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
                 </article>
-                <article class="emotes-menu grid doublecolumn">
+                <article class="menu animalemotes-menu doublecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 5</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 6</button>
                 </article>
-                <article class="emotes-menu grid triplecolumn">
+                <article class="menu sharedemotes-menu doublecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 5</button>
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 6</button>
+                </article>
+                <article class="menu propemotes-menu doublecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                </article>
+                <article class="menu danceemotes-menu doublecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                </article>
+                <article class="menu keybinds-menu singlecolumn">
+                    Keybinds
+                </article>
+                <article class="menu favorites-menu doublecolumn">
+                    <button class="btn btn-emote btn-emote-favorite" data-emoteid="emote1">Emote 1</button>
+                </article>
+                <article class="menu walkstyles-menu doublecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                </article>
+                <article class="menu moods-menu doublecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                </article>
+                <article class="menu emojis-menu triplecolumn">
+                    <button class="btn btn-emoji" data-emoji="emote1">😀</button>
                 </article>
             </section>
         </main>
         <footer class="footer-container">
-            <span><small>Some footer text here.</small></span>
+            <span class="footer-text">&nbsp;</span>
         </footer>
     </div>
 </body>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -18,14 +18,13 @@
         <header class="header-container">
             <img src="/header.png" alt="RP Emotes" class="header-image">
         </header>
-        <main class="menu-container">
+        <main class="menu-container" tabindex="-1">
             <nav class="side-navigation invisible-scrollbar">
                 <ul>
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
                         <span class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</span>
                     </li>
-                    <hr />
                     <li class="sidebar-button-container sidebar-button-active">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
                         <span class="btn-sidebar-label" data-locale="emotes">Emotes</span>
@@ -93,7 +92,7 @@
                 <article class="menu walkstyles-menu doublecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
-                <article class="menu moods-menu doublecolumn">
+                <article class="menu moods-menu singlecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
                 <article class="menu emojis-menu triplecolumn">

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -25,22 +25,11 @@
                         <button class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
                         <span class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</span>
                     </li>
-                    <li class="sidebar-button-container sidebar-button-active">
+                    <li class="sidebar-button-container sidebar-button-active sidebar-button-anchor">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
                         <span class="btn-sidebar-label" data-locale="emotes">Emotes</span>
                     </li>
-                    <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="sharedemotes-menu">👫</button>
-                        <span class="btn-sidebar-label" data-locale="shareemotes">Shared Emotes</span>
-                    </li>
-                    <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="propemotes-menu">📦</button>
-                        <span class="btn-sidebar-label" data-locale="propemotes">Prop Emotes</span>
-                    </li>
-                    <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="danceemotes-menu">🕺</button>
-                        <span class="btn-sidebar-label" data-locale="danceemotes">Dance Emotes</span>
-                    </li>
+                    <!-- Custom Emote Groups added here -->
                     <li class="sidebar-button-container">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="keybinds-menu">🔢</button>
                         <span class="btn-sidebar-label" data-locale="keybinds">Keybinds</span>
@@ -68,21 +57,10 @@
                     <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search..." data-locale="searchemotes">
                     <input type="reset" value="x" class="btn btn-clear-search"></input>
                 </form>
-                <article class="menu emotes-menu grid doublecolumn">
+                <article class="menu menu-anchor emotes-menu grid doublecolumn">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
-                <article class="menu animalemotes-menu doublecolumn">
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                </article>
-                <article class="menu sharedemotes-menu doublecolumn">
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                </article>
-                <article class="menu propemotes-menu doublecolumn">
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                </article>
-                <article class="menu danceemotes-menu doublecolumn">
-                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
-                </article>
+                <!-- Custom Emote Groups added here -->
                 <article class="menu keybinds-menu singlecolumn">
                     <ul class="keybinds-list">
                         <li>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en"> <!-- TODO: do some JS stuff to also change this to the correct locale. -->
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RPEmotes-Reborn</title>
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/dynamic.css">
+    <link rel="stylesheet" href="css/overrides.css">
+
+    <script type="module" src="js/classes.js" defer></script>
+    <script type="module" src="js/data.js" defer></script>
+    <script type="module" src="js/main.js" defer></script>
+</head>
+<body>
+    <div class="main-container noselect">
+        <header class="header-container">
+            <img src="/header.png" alt="RP Emotes" class="header-image">
+        </header>
+        <main class="menu-container">
+            <nav class="side-navigation invisible-scrollbar">
+                <ul>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
+                        <span class="btn-sidebar-label">Cancel Emote</span>
+                    </li>
+                    <hr />
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
+                        <span class="btn-sidebar-label">Emotes</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="sharedemotes-menu">👫</button>
+                        <span class="btn-sidebar-label">Shared Emotes</span>
+                    </li>
+                    <li class="sidebar-button-container sidebar-button-active">
+                        <button class="btn btn-sidebar btn-active" data-action="openMenu" data-menu="propemotes-menu">📦</button>
+                        <span class="btn-sidebar-label">Prop Emotes</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="danceemotes-menu">🕺</button>
+                        <span class="btn-sidebar-label">Dance Emotes</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="keybinds-menu">🔢</button>
+                        <span class="btn-sidebar-label">Keybinds</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="favorites-menu">🌟</button>
+                        <span class="btn-sidebar-label">Favorites</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="walkstyles-menu">🚶🏻‍♂️</button>
+                        <span class="btn-sidebar-label">Walk Styles</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="moods-menu">🎭</button>
+                        <span class="btn-sidebar-label">Moods</span>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="emojis-menu">😀</button>
+                        <span class="btn-sidebar-label">Emojis</span>
+                    </li>
+                </ul>
+            </nav>
+            <section class="content-container invisible-scrollbar">
+                <form class="search-container">
+                    <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search [EMOTE_MENU_NAME]...">
+                    <input type="reset" value="x" class="btn btn-clear-search"></input>
+                </form>
+                <article class="emotes-menu grid singlecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
+                </article>
+                <article class="emotes-menu grid doublecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 5</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 6</button>
+                </article>
+                <article class="emotes-menu grid triplecolumn">
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 2</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 3</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 4</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 5</button>
+                    <button class="btn btn-emote" data-emoteid="emote1">Emote 6</button>
+                </article>
+            </section>
+        </main>
+        <footer class="footer-container">
+            <span><small>Some footer text here.</small></span>
+        </footer>
+    </div>
+</body>
+</html>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"> <!-- TODO: do some JS stuff to also change this to the correct locale. -->
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -84,7 +84,11 @@
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
                 <article class="menu keybinds-menu singlecolumn">
-                    Keybinds
+                    <ul class="keybinds-list">
+                        <li>
+                            <p class="keybind-description" data-locale="keybind_description"></p>
+                        </li>
+                    </ul>
                 </article>
                 <article class="menu favorites-menu doublecolumn">
                     <button class="btn btn-emote btn-emote-favorite" data-emoteid="emote1">Emote 1</button>

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -3,9 +3,8 @@
 import { HandleLocales } from "./utils.js";
 
 export class Popover {
-    constructor(triggerSelector, popoverHTML) {
+    constructor(triggerSelector) {
         this.triggerSelector = triggerSelector;
-        this.popoverHTML = popoverHTML;
         this.currentPopover = null;
         this.currentButton = null;
         this.init();
@@ -13,29 +12,53 @@ export class Popover {
 
     init() {
         document.addEventListener('contextmenu', (e) => {
-            if (e.target.closest(this.triggerSelector)) {
+            console.log(e);
+            let event = JSON.parse(JSON.stringify(e));
+            event.target = document.activeElement;
+            const rect = event.target.getBoundingClientRect();
+            event.clientX = rect.left + rect.width/2;
+            event.clientY = rect.top + rect.height/2;
+            if (event.target.closest(this.triggerSelector)) {
                 e.preventDefault();
-                this.currentButton = e.target.closest(this.triggerSelector);
-                this.show(e);
+                console.log("run")
+                this.currentButton = event.target.closest(this.triggerSelector);
+                this.show(event);
             }
         });
 
         // Close popover on click outside
-        document.addEventListener('click', () => this.hide());
+        document.addEventListener('click', (e) => {if (!e.shiftKey) this.hide()});
         
-        // Close popover on Escape key
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape') this.hide();
+        document.addEventListener('keyup', (e) => {
+            if (e.key === 'Escape' || e.key === "Backspace") {
+                if (document.querySelector(".popover")) {
+                    this.currentButton?.focus();
+                    this.hide();
+                }
+            }
         });
     }
 
     show(event) {
         this.hide(); // Close any existing popover
 
+        const data = {
+            emoteId: this.currentButton.dataset.emoteid,
+            emoteType: this.currentButton.dataset.emoteType,
+            isFavorite: this.currentButton.classList.contains("btn-emote-favorite")
+        }
+
         const popover = document.createElement('div');
         popover.className = 'popover';
-        popover.innerHTML = this.popoverHTML;
         document.body.appendChild(popover);
+
+        if (data.emoteId) {
+            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>`)
+            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>`)
+            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="keybind">${Locale.translate("btn_setkeybind")}</button>`)
+            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="favorite">${data.isFavorite ? Locale.translate("btn_remove_favorite") : Locale.translate("btn_set_favorite")}</button>`)
+        }
+        popover.firstElementChild?.focus();
 
         // Position popover
         popover.style.left = (event.clientX) + 'px';
@@ -63,7 +86,7 @@ export class Popover {
                     detail: {
                         action: action,
                         button: this.currentButton,
-                        emoteId: this.currentButton.dataset.emoteid,
+                        data: data,
                         event: e
                     }
                 });

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -1,0 +1,100 @@
+"use strict";
+
+import { HandleLocales } from "./utils.js";
+
+export class Popover {
+    constructor(triggerSelector, popoverHTML) {
+        this.triggerSelector = triggerSelector;
+        this.popoverHTML = popoverHTML;
+        this.currentPopover = null;
+        this.currentButton = null;
+        this.init();
+    }
+
+    init() {
+        document.addEventListener('contextmenu', (e) => {
+            if (e.target.closest(this.triggerSelector)) {
+                e.preventDefault();
+                this.currentButton = e.target.closest(this.triggerSelector);
+                this.show(e);
+            }
+        });
+
+        // Close popover on click outside
+        document.addEventListener('click', () => this.hide());
+        
+        // Close popover on Escape key
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') this.hide();
+        });
+    }
+
+    show(event) {
+        this.hide(); // Close any existing popover
+
+        const popover = document.createElement('div');
+        popover.className = 'popover';
+        popover.innerHTML = this.popoverHTML;
+        document.body.appendChild(popover);
+
+        // Position popover
+        popover.style.left = (event.clientX) + 'px';
+        popover.style.top = (event.clientY) + 'px';
+
+        // Adjust if it goes off-screen
+        const popoverRect = popover.getBoundingClientRect();
+        if (popoverRect.right > window.innerWidth) {
+            popover.style.left = (event.clientX - popoverRect.width) + 'px';
+        }
+        if (popoverRect.bottom > window.innerHeight) {
+            popover.style.top = (event.clientY - popoverRect.height) + 'px';
+        }
+
+        this.currentPopover = popover;
+
+        // Stop propagation to avoid immediate close
+        popover.addEventListener('click', (e) => e.stopPropagation());
+
+        // Dispatch custom event with button context
+        popover.addEventListener('click', (e) => {
+            const action = e.target.closest('.popover-menu-item')?.dataset.action;
+            if (action) {
+                const event = new CustomEvent('popoverAction', {
+                    detail: {
+                        action: action,
+                        button: this.currentButton,
+                        emoteId: this.currentButton.dataset.emoteid,
+                        event: e
+                    }
+                });
+                document.dispatchEvent(event);
+                this.hide();
+            }
+        });
+    }
+
+    hide() {
+        if (this.currentPopover) {
+            this.currentPopover.remove();
+            this.currentPopover = null;
+        }
+    }
+}
+
+
+export class Locale {
+    static LOCALES = {};
+
+    constructor() {
+        HandleLocales().then((retval) => {
+            Locale.LOCALES = retval
+            const event = new CustomEvent('localesLoaded');
+            document.dispatchEvent(event);
+        });
+    }
+
+    static translate(key) {
+        if (Locale.LOCALES[key]) return Locale.LOCALES[key];
+        return String(key);
+    }
+}

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -123,7 +123,6 @@ export class Popover {
 
     static setKeybindSlots(slots) {
         Popover._keybindSlots = Number(slots) || 0;
-        console.log(Popover._keybindSlots)
     }
 }
 

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -3,6 +3,8 @@
 import { HandleLocales, querySelectorVisible } from "./utils.js";
 
 export class Popover {
+    _keybindSlots = 0;
+
     constructor(triggerSelector) {
         this.triggerSelector = triggerSelector;
         this.currentPopover = null;
@@ -57,13 +59,10 @@ export class Popover {
                 }
                 popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="favorite">${data.isFavorite ? Locale.translate("btn_remove_favorite") : Locale.translate("btn_set_favorite")}</button>`)
 
-                //TODO: This needs to be a list.
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="1">${Locale.translate("btn_setkeybind")} (1)</button>`)
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="2">${Locale.translate("btn_setkeybind")} (2)</button>`)
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="3">${Locale.translate("btn_setkeybind")} (3)</button>`)
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="4">${Locale.translate("btn_setkeybind")} (4)</button>`)
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="5">${Locale.translate("btn_setkeybind")} (5)</button>`)
-                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="6">${Locale.translate("btn_setkeybind")} (6)</button>`)
+                //TODO: This needs to be a HTML list.
+                for (let i = 1; i <= Popover._keybindSlots; i++) {
+                    popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="${i}">${Locale.translate("btn_setkeybind")} (${i})</button>`)
+                }
             } else {
                 popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="clear-keybind">${Locale.translate("btn_delkeybind")}</button>`)
             }
@@ -120,6 +119,11 @@ export class Popover {
                 querySelectorVisible(document.querySelector(".grid"))
             }
         }
+    }
+
+    static setKeybindSlots(slots) {
+        Popover._keybindSlots = Number(slots) || 0;
+        console.log(Popover._keybindSlots)
     }
 }
 

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { HandleLocales } from "./utils.js";
+import { HandleLocales, querySelectorVisible } from "./utils.js";
 
 export class Popover {
     constructor(triggerSelector) {
@@ -12,7 +12,6 @@ export class Popover {
 
     init() {
         document.addEventListener('contextmenu', (e) => {
-            console.log(e);
             let event = JSON.parse(JSON.stringify(e));
             event.target = document.activeElement;
             const rect = event.target.getBoundingClientRect();
@@ -20,7 +19,6 @@ export class Popover {
             event.clientY = rect.top + rect.height/2;
             if (event.target.closest(this.triggerSelector)) {
                 e.preventDefault();
-                console.log("run")
                 this.currentButton = event.target.closest(this.triggerSelector);
                 this.show(event);
             }
@@ -32,7 +30,6 @@ export class Popover {
         document.addEventListener('keyup', (e) => {
             if (e.key === 'Escape' || e.key === "Backspace") {
                 if (document.querySelector(".popover")) {
-                    this.currentButton?.focus();
                     this.hide();
                 }
             }
@@ -44,7 +41,7 @@ export class Popover {
 
         const data = {
             emoteId: this.currentButton.dataset.emoteid,
-            emoteType: this.currentButton.dataset.emoteType,
+            emoteType: this.currentButton.dataset.emotetype,
             isFavorite: this.currentButton.classList.contains("btn-emote-favorite")
         }
 
@@ -53,10 +50,26 @@ export class Popover {
         document.body.appendChild(popover);
 
         if (data.emoteId) {
-            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>`)
-            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>`)
-            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="keybind">${Locale.translate("btn_setkeybind")}</button>`)
-            popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="favorite">${data.isFavorite ? Locale.translate("btn_remove_favorite") : Locale.translate("btn_set_favorite")}</button>`)
+            if (!this.currentButton.classList.contains("btn-keybind")) {
+                if (data.emoteType && data.emoteType !== "Emojis" && data.emoteType !== "Expressions" && data.emoteType !== "Walks" && data.emoteType !== "Shared") {
+                    popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>`)
+                    popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>`)
+                }
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="favorite">${data.isFavorite ? Locale.translate("btn_remove_favorite") : Locale.translate("btn_set_favorite")}</button>`)
+
+                //TODO: This needs to be a list.
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="1">${Locale.translate("btn_setkeybind")} (1)</button>`)
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="2">${Locale.translate("btn_setkeybind")} (2)</button>`)
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="3">${Locale.translate("btn_setkeybind")} (3)</button>`)
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="4">${Locale.translate("btn_setkeybind")} (4)</button>`)
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="5">${Locale.translate("btn_setkeybind")} (5)</button>`)
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="6">${Locale.translate("btn_setkeybind")} (6)</button>`)
+            } else {
+                popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="clear-keybind">${Locale.translate("btn_delkeybind")}</button>`)
+            }
+        } else {
+            this.hide()
+            return;
         }
         popover.firstElementChild?.focus();
 
@@ -86,6 +99,7 @@ export class Popover {
                     detail: {
                         action: action,
                         button: this.currentButton,
+                        popoverButton: e.target.closest('.popover-menu-item'),
                         data: data,
                         event: e
                     }
@@ -100,6 +114,11 @@ export class Popover {
         if (this.currentPopover) {
             this.currentPopover.remove();
             this.currentPopover = null;
+            if (this.currentButton) {
+                this.currentButton.focus();
+            } else {
+                querySelectorVisible(document.querySelector(".grid"))
+            }
         }
     }
 }

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -7,7 +7,7 @@ const SIDE_NAVIGATION = document.querySelector(".side-navigation");
 const CONTENT_CONTAINER = document.querySelector(".content-container");
 const SEARCH_CONTAINER = document.querySelector(".search-container");
 const SEARCH_BAR = SEARCH_CONTAINER.querySelector(".search-input");
-const MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
+let MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
 const FOOTER_TEXT = document.querySelector(".footer-text");
 
 let EMOTE_TYPE_ICONS = {}
@@ -72,45 +72,47 @@ SIDE_NAVIGATION.addEventListener("click", (e) => {
 
 let sendPreviewRequest = true
 
-MENUS.forEach((element) => {
-    element.addEventListener("mouseover", (e) => {
-        const TARGET = e.target;
-        if (!TARGET.dataset.emoteid) {
-            FOOTER_TEXT.innerHTML = "&nbsp;"
-            return;
-        }
+function _setupMenuEventListeners(MENUS) {
+    MENUS.forEach((element) => {
+        element.addEventListener("mouseover", (e) => {
+            const TARGET = e.target;
+            if (!TARGET.dataset.emoteid) {
+                FOOTER_TEXT.innerHTML = "&nbsp;"
+                return;
+            }
+        })
+
+        element.addEventListener("focusin", (e) => {
+            const TARGET = e.target;
+            PlaySoundFrontend("NAV_UP_DOWN")
+            if (!TARGET.dataset.emoteid || TARGET.dataset.emotetype === "Emojis" || TARGET.dataset.emotetype === "Expressions" || TARGET.dataset.emotetype === "Walks") {
+                FOOTER_TEXT.innerHTML = "&nbsp;"
+
+                let _previewData = {}
+                if (TARGET.dataset.emotetype === "Expressions") _previewData = {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}
+                ExecuteNUICallback("PREVIEW_EMOTE", _previewData)
+                return;
+            }
+
+            if (sendPreviewRequest) ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
+
+            FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
+        })
+
+        element.addEventListener("click", (e) => {
+            e.preventDefault();
+            const TARGET = e.target;
+            if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
+            PlaySoundFrontend("SELECT");
+            if (e.shiftKey) {
+                // Bodge to trick the browser into thinking we right-clicked, when in fact we Shift+Entered.
+                document.dispatchEvent(new CustomEvent('contextmenu', { detail: {}}));
+                return;
+            }
+            ExecuteNUICallback("ROUTE_EMOTE", {type: "emote", emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
+        })
     })
-
-    element.addEventListener("focusin", (e) => {
-        const TARGET = e.target;
-        PlaySoundFrontend("NAV_UP_DOWN")
-        if (!TARGET.dataset.emoteid || TARGET.dataset.emotetype === "Emojis" || TARGET.dataset.emotetype === "Expressions" || TARGET.dataset.emotetype === "Walks") {
-            FOOTER_TEXT.innerHTML = "&nbsp;"
-
-            let _previewData = {}
-            if (TARGET.dataset.emotetype === "Expressions") _previewData = {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}
-            ExecuteNUICallback("PREVIEW_EMOTE", _previewData)
-            return;
-        }
-
-        if (sendPreviewRequest) ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
-
-        FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
-    })
-
-    element.addEventListener("click", (e) => {
-        e.preventDefault();
-        const TARGET = e.target;
-        if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
-        PlaySoundFrontend("SELECT");
-        if (e.shiftKey) {
-            // Bodge to trick the browser into thinking we right-clicked, when in fact we Shift+Entered.
-            document.dispatchEvent(new CustomEvent('contextmenu', { detail: {}}));
-            return;
-        }
-        ExecuteNUICallback("ROUTE_EMOTE", {type: "emote", emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
-    })
-})
+}
 
 SEARCH_CONTAINER.addEventListener("submit", (e) => {
     e.preventDefault();
@@ -136,8 +138,29 @@ window.addEventListener('message', (event) => {
     }
 
     if (event.data.type === 'LOAD_EMOTE_DATA') {
-        // event.data.emoteData && event.data.categoryToEmotes && event.data.emoteTypeIcons
+        // event.data.emoteData && event.data.categoryToEmotes && event.data.emoteCategories && event.data.emoteTypeIcons
         EMOTE_TYPE_ICONS = event.data.emoteTypeIcons || {}
+        const emoteCategories = event.data.emoteCategories
+        Object.keys(emoteCategories).forEach((key) => {
+            const SIDEBAR_ANCHOR = document.querySelector(".sidebar-button-anchor");
+            const MENU_ANCHOR = document.querySelector(".menu-anchor");
+            
+            SIDEBAR_ANCHOR.insertAdjacentHTML("afterend",
+                `
+                    <li class="sidebar-button-container">
+                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="${emoteCategories[key].id}-menu">${emoteCategories[key].icon}</button>
+                        <span class="btn-sidebar-label">${key}</span>
+                    </li>
+                `);
+
+            MENU_ANCHOR.insertAdjacentHTML("afterend",
+                `
+                <article class="menu ${emoteCategories[key].id}-menu doublecolumn">Hiii
+                </article>
+                `)
+        })
+        MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
+        _setupMenuEventListeners(MENUS);
     }
 
     if (event.data.type === 'BUILD_EMOTE_MENUS') {
@@ -149,14 +172,14 @@ window.addEventListener('message', (event) => {
                 event.data[key].forEach((el) => {
                     if (el) {
                         EMOTES.insertAdjacentHTML("beforeend", `
-                            <button class="btn btn-emote ${el.isFavorite ? "btn-emote-favorite" : ""} ${el.emoteType === "Emojis" ? "noto-color-emoji-regular" : ""}" data-emoteid="${el.id}" data-emoteType="${el.emoteType}" data-label="${el.label}">${el.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[el.emoteType]+" " : ""}${el.label}</button>
+                            <button class="btn btn-emote ${el.isFavorite ? "btn-emote-favorite" : ""} ${el.emoteType === "Emojis" ? "noto-color-emoji-regular" : ""}" data-emoteid="${el.emoteName}" data-emoteType="${el.emoteType}" data-label="${el.label}">${el.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[el.emoteType]+" " : ""}${el.label}</button>
                             `)
                     }
                 })
             }
         })
         event.data.favorites?.forEach((emote) => {
-            const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.id}"]`));
+            const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.emoteName}"]`));
             ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
         })
     }

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -131,6 +131,10 @@ window.addEventListener('message', (event) => {
         document.querySelector(".btn-sidebar").focus();
     }
 
+    if (event.data.type === 'TOGGLE_CURSOR_INPUT') {
+        (event.data.value ? document.body.classList.remove("no-cursor") : document.body.classList.add("no-cursor"))
+    }
+
     if (event.data.type === 'LOAD_EMOTE_DATA') {
         // event.data.emoteData && event.data.categoryToEmotes && event.data.emoteTypeIcons
         EMOTE_TYPE_ICONS = event.data.emoteTypeIcons || {}

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -1,11 +1,12 @@
 "use strict";
-import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback } from './utils.js';
+import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback, PlaySoundFrontend, HandleEmoteSearch } from './utils.js';
 import { Locale, Popover } from './classes.js'
 
 
 const SIDE_NAVIGATION = document.querySelector(".side-navigation");
 const CONTENT_CONTAINER = document.querySelector(".content-container");
 const SEARCH_CONTAINER = document.querySelector(".search-container");
+const SEARCH_BAR = SEARCH_CONTAINER.querySelector(".search-input");
 const MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
 const FOOTER_TEXT = document.querySelector(".footer-text");
 
@@ -54,6 +55,8 @@ SIDE_NAVIGATION.addEventListener("click", (e) => {
     }
 })
 
+let sendPreviewRequest = true
+
 MENUS.forEach((element) => {
     element.addEventListener("mouseover", (e) => {
         const TARGET = e.target;
@@ -61,17 +64,19 @@ MENUS.forEach((element) => {
             FOOTER_TEXT.innerHTML = "&nbsp;"
             return;
         }
-            
-        FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
     })
 
     element.addEventListener("focusin", (e) => {
         const TARGET = e.target;
+        PlaySoundFrontend("NAV_UP_DOWN")
         if (!TARGET.dataset.emoteid) {
             FOOTER_TEXT.innerHTML = "&nbsp;"
+            ExecuteNUICallback("PREVIEW_EMOTE", {})
             return;
         }
-            
+
+        if (sendPreviewRequest) ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
+        
         FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
     })
 
@@ -79,19 +84,26 @@ MENUS.forEach((element) => {
         e.preventDefault();
         const TARGET = e.target;
         if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
-
+        PlaySoundFrontend("SELECT");
         ExecuteNUICallback("ROUTE_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
     })
 })
 
 SEARCH_CONTAINER.addEventListener("submit", (e) => {
     e.preventDefault();
+    HandleEmoteSearch();
+})
+
+SEARCH_BAR.addEventListener("input", (e) => {
+    if (SEARCH_BAR.value.length > 2) HandleEmoteSearch();
+    else HandleEmoteSearch("");
 })
 
 
 window.addEventListener('message', (event) => {
     if (event.data.type === 'OPEN_MENU') {
         (event.data.value ? document.body.style.display = "flex" : document.body.style.display = "none")
+        document.querySelector(".btn-sidebar").focus();
     }
 
     if (event.data.type === 'LOAD_EMOTE_DATA') {

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -1,5 +1,5 @@
 "use strict";
-import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback, PlaySoundFrontend, HandleEmoteSearch } from './utils.js';
+import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback, PlaySoundFrontend, HandleEmoteSearch, querySelectorVisible } from './utils.js';
 import { Locale, Popover } from './classes.js'
 
 
@@ -14,11 +14,11 @@ let EMOTE_TYPE_ICONS = {}
 
 window.addEventListener("load", async (e) => {
     ExecuteNUICallback("NUI_READY", {}).finally(() => {})
-    const LOCALES = new Locale(); // We just need to init this after the everything is loaded.
+    const LOCALES = new Locale(); // We just need to init this after the everything is loaded. The class statics will handle everything.
 })
 
 document.addEventListener('popoverAction', (e) => {
-    const { action, button, emoteId, event } = e.detail;
+    const { action, button, popoverButton, emoteId, event } = e.detail;
     switch (action) {
         case 'groupemote':
             ExecuteNUICallback("ROUTE_EMOTE", {type: "groupemote", emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype})
@@ -26,10 +26,30 @@ document.addEventListener('popoverAction', (e) => {
         case 'placement':
             ExecuteNUICallback("ROUTE_EMOTE", {type: "placement", emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype})
             break;
-        case 'keybind':
+        case 'set-keybind':
+            ExecuteNUICallback("KEYBIND_EMOTE", {type: "set", id: (popoverButton && popoverButton.dataset.slotid) || 1, emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype, emoteLabel: button.dataset.label})
+            if (!document.activeElement || document.activeElement.nodeName !== "BUTTON") querySelectorVisible(document.querySelector(".grid"))?.focus();
+            break;
+        case 'clear-keybind':
+            ExecuteNUICallback("KEYBIND_EMOTE", {type: "clear", id: button.dataset.slotid, emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype})
             break;
         case 'favorite':
-            ExecuteNUICallback("FAVORITE_EMOTE", {emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype, emoteLabel: button.dataset.label})
+            ExecuteNUICallback("FAVORITE_EMOTE", {emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype, emoteLabel: button.dataset.label}).then( async (res) => {
+                const result = await res.json();
+                if (!result.favorites) return;
+                const ELEMENTS = Array.from(document.querySelectorAll(`.btn-emote-favorite`));
+                const MENU = document.querySelector(".favorites-menu")
+                ClearHTMLContainer(".favorites-menu");
+                ELEMENTS.forEach((el) => el?.classList.remove("btn-emote-favorite"));
+                result.favorites?.forEach((emote) => {
+                    const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.name}"]`));
+                    ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
+                    MENU.insertAdjacentHTML("beforeend", `
+                            <button class="btn btn-emote btn-emote-favorite" data-emoteid="${emote.name}" data-emoteType="${emote.emoteType}" data-label="${emote.label}">${emote.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[emote.emoteType]+" " : ""}${emote.label}</button>
+                            `)
+                })
+                if (!document.activeElement || document.activeElement.nodeName !== "BUTTON") querySelectorVisible(document.querySelector(".grid"))?.focus();
+            })
             break;
     }
 });
@@ -70,12 +90,15 @@ MENUS.forEach((element) => {
         PlaySoundFrontend("NAV_UP_DOWN")
         if (!TARGET.dataset.emoteid || TARGET.dataset.emotetype === "Emojis" || TARGET.dataset.emotetype === "Expressions" || TARGET.dataset.emotetype === "Walks") {
             FOOTER_TEXT.innerHTML = "&nbsp;"
-            ExecuteNUICallback("PREVIEW_EMOTE", {})
+            // TODO: better than this.
+            let _previewData = {}
+            if (TARGET.dataset.emotetype === "Expressions") _previewData = {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}
+            ExecuteNUICallback("PREVIEW_EMOTE", _previewData)
             return;
         }
 
         if (sendPreviewRequest) ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
-        
+
         FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
     })
 
@@ -85,7 +108,8 @@ MENUS.forEach((element) => {
         if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
         PlaySoundFrontend("SELECT");
         if (e.shiftKey) {
-            console.log("Hi")
+            // Hack to trick the browser into thinking we right-clicked, when in fact we Shift+Entered.
+            // We do this to avoid actually writing good code for the popover. R*, please update CEF.
             document.dispatchEvent(new CustomEvent('contextmenu', { detail: {}}));
             return;
         }
@@ -137,6 +161,32 @@ window.addEventListener('message', (event) => {
             const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.id}"]`));
             ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
         })
+    }
+
+    if (event.data.type === "BUILD_KEYBINDS_MENU") {
+        // This runs every time the player opens the emote menu.
+        // We need it to run like this because we don't know when the player will change their keybinds in the settings.
+        const kbinds = event.data.keybinds
+        const KEYBINDS_LIST_CONTAINER = document.querySelector(".keybinds-list");
+
+        const BIND_ITEMS = Array.from(document.querySelectorAll(".keybinds-list-item"));
+        BIND_ITEMS?.forEach((el) => el.remove());
+
+        Object.keys(kbinds).sort().forEach((key) => {
+            const data = kbinds[key]
+            KEYBINDS_LIST_CONTAINER?.insertAdjacentHTML("beforeend",
+                `
+                <li class="keybinds-list-item">
+                    <span class="keybind-item-text">Slot ${data.id} [ <span class="keybind-bind-text keybind-${data.id}-bind">${data.keyLabel}</span> ]</span>
+                    <button class="btn btn-emote btn-keybind" data-emoteid="${data.emoteName}" data-emoteType="${data.emoteType}" data-slotid="${data.id}">${data.emoteType && data.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[data.emoteType]+" " : ""}${data.emoteLabel || data.emoteName || Locale.translate("empty_slot")}</button>
+                </li>
+                `
+
+            )
+        })
+        if (document.querySelector(".keybinds-menu.grid")) {
+            querySelectorVisible(document.querySelector(".keybinds-list"))?.focus(); // This feels bad... It works, but I really don't want to look at it.
+        }
     }
 });
 

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -10,6 +10,8 @@ const SEARCH_BAR = SEARCH_CONTAINER.querySelector(".search-input");
 const MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
 const FOOTER_TEXT = document.querySelector(".footer-text");
 
+let EMOTE_TYPE_ICONS = {}
+
 window.addEventListener("load", async (e) => {
     ExecuteNUICallback("NUI_READY", {}).finally(() => {})
     const LOCALES = new Locale(); // We just need to init this after the everything is loaded.
@@ -19,12 +21,15 @@ document.addEventListener('popoverAction', (e) => {
     const { action, button, emoteId, event } = e.detail;
     switch (action) {
         case 'groupemote':
+            ExecuteNUICallback("ROUTE_EMOTE", {type: "groupemote", emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype})
             break;
         case 'placement':
+            ExecuteNUICallback("ROUTE_EMOTE", {type: "placement", emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype})
             break;
         case 'keybind':
             break;
         case 'favorite':
+            ExecuteNUICallback("FAVORITE_EMOTE", {emoteName: button.dataset.emoteid, emoteType: button.dataset.emotetype, emoteLabel: button.dataset.label})
             break;
     }
 });
@@ -33,13 +38,7 @@ document.addEventListener('localesLoaded', (e) => {
     // Handler for Right-click menu.
     // Can we please have updated CEF in FiveM? I want my Popover API. --CritteR
     /////////////////////////////////////////////////////////////////////////////////
-    const emotePopover = new Popover('.btn-emote', `
-        <p>/e somecommand</p>
-        <button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>
-        <button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>
-        <button class="popover-menu-item" data-action="keybind">${Locale.translate("btn_setkeybind")}</button>
-        <button class="popover-menu-item" data-action="favorite">${Locale.translate("btn_set_favorite")}</button>
-    `);
+    const emotePopover = new Popover('.btn-emote');
 })
 
 
@@ -69,7 +68,7 @@ MENUS.forEach((element) => {
     element.addEventListener("focusin", (e) => {
         const TARGET = e.target;
         PlaySoundFrontend("NAV_UP_DOWN")
-        if (!TARGET.dataset.emoteid) {
+        if (!TARGET.dataset.emoteid || TARGET.dataset.emotetype === "Emojis" || TARGET.dataset.emotetype === "Expressions" || TARGET.dataset.emotetype === "Walks") {
             FOOTER_TEXT.innerHTML = "&nbsp;"
             ExecuteNUICallback("PREVIEW_EMOTE", {})
             return;
@@ -85,7 +84,12 @@ MENUS.forEach((element) => {
         const TARGET = e.target;
         if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
         PlaySoundFrontend("SELECT");
-        ExecuteNUICallback("ROUTE_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
+        if (e.shiftKey) {
+            console.log("Hi")
+            document.dispatchEvent(new CustomEvent('contextmenu', { detail: {}}));
+            return;
+        }
+        ExecuteNUICallback("ROUTE_EMOTE", {type: "emote", emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
     })
 })
 
@@ -94,9 +98,11 @@ SEARCH_CONTAINER.addEventListener("submit", (e) => {
     HandleEmoteSearch();
 })
 
+
+let lastSearchInputValue = ""
 SEARCH_BAR.addEventListener("input", (e) => {
-    if (SEARCH_BAR.value.length > 2) HandleEmoteSearch();
-    else HandleEmoteSearch("");
+    if (SEARCH_BAR.value !== lastSearchInputValue) HandleEmoteSearch();
+    lastSearchInputValue = SEARCH_BAR.value
 })
 
 
@@ -107,13 +113,11 @@ window.addEventListener('message', (event) => {
     }
 
     if (event.data.type === 'LOAD_EMOTE_DATA') {
-        // event.data.emoteData && event.data.categoryToEmotes
+        // event.data.emoteData && event.data.categoryToEmotes && event.data.emoteTypeIcons
+        EMOTE_TYPE_ICONS = event.data.emoteTypeIcons || {}
     }
 
     if (event.data.type === 'BUILD_EMOTE_MENUS') {
-        // event.data
-        console.log(event.data)
-
         Object.keys(event.data).forEach((key) => {
             if (key !== "type" && key !== "keybinds") {
                 const EMOTES = CONTENT_CONTAINER.querySelector(`.${key}-menu`);
@@ -122,11 +126,16 @@ window.addEventListener('message', (event) => {
                 event.data[key].forEach((el) => {
                     if (el) {
                         EMOTES.insertAdjacentHTML("beforeend", `
-                            <button class="btn btn-${el.emoteType === "Emojis" ? "emoji" : "emote"} ${el.isFavorite ? "btn-emote-favorite" : ""}" data-emoteid="${el.id}" data-emoteType="${el.emoteType}">${el.label}</button>
+                            <button class="btn btn-emote ${el.isFavorite ? "btn-emote-favorite" : ""} ${el.emoteType === "Emojis" ? "noto-color-emoji-regular" : ""}" data-emoteid="${el.id}" data-emoteType="${el.emoteType}" data-label="${el.label}">${el.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[el.emoteType]+" " : ""}${el.label}</button>
                             `)
                     }
                 })
             }
+        })
+        event.data.favorites?.forEach((emote) => {
+            //bruh momment
+            const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.id}"]`));
+            ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
         })
     }
 });

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -56,15 +56,11 @@ document.addEventListener('popoverAction', (e) => {
 
 document.addEventListener('localesLoaded', (e) => {
     // Handler for Right-click menu.
-    // Can we please have updated CEF in FiveM? I want my Popover API. --CritteR
-    /////////////////////////////////////////////////////////////////////////////////
+    // All logic is done through the class, sadly. Sends a `popoverAction` custom event when a button is used.
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////
     const emotePopover = new Popover('.btn-emote');
 })
 
-
-// Sidebar Logic. We just handle everything in the utils anyway, to keep this file tidy.
-// No, I will not stop over-commeting. Why do you ask?
-////////////////////////////////////////////////////////////////////////////////////
 SIDE_NAVIGATION.addEventListener("click", (e) => {
     const TARGET = e.target;
 
@@ -90,7 +86,7 @@ MENUS.forEach((element) => {
         PlaySoundFrontend("NAV_UP_DOWN")
         if (!TARGET.dataset.emoteid || TARGET.dataset.emotetype === "Emojis" || TARGET.dataset.emotetype === "Expressions" || TARGET.dataset.emotetype === "Walks") {
             FOOTER_TEXT.innerHTML = "&nbsp;"
-            // TODO: better than this.
+
             let _previewData = {}
             if (TARGET.dataset.emotetype === "Expressions") _previewData = {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}
             ExecuteNUICallback("PREVIEW_EMOTE", _previewData)
@@ -108,8 +104,7 @@ MENUS.forEach((element) => {
         if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
         PlaySoundFrontend("SELECT");
         if (e.shiftKey) {
-            // Hack to trick the browser into thinking we right-clicked, when in fact we Shift+Entered.
-            // We do this to avoid actually writing good code for the popover. R*, please update CEF.
+            // Bodge to trick the browser into thinking we right-clicked, when in fact we Shift+Entered.
             document.dispatchEvent(new CustomEvent('contextmenu', { detail: {}}));
             return;
         }
@@ -157,7 +152,6 @@ window.addEventListener('message', (event) => {
             }
         })
         event.data.favorites?.forEach((emote) => {
-            //bruh momment
             const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.id}"]`));
             ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
         })
@@ -185,8 +179,10 @@ window.addEventListener('message', (event) => {
             )
         })
         if (document.querySelector(".keybinds-menu.grid")) {
-            querySelectorVisible(document.querySelector(".keybinds-list"))?.focus(); // This feels bad... It works, but I really don't want to look at it.
+            querySelectorVisible(document.querySelector(".keybinds-list"))?.focus();
         }
+
+        Popover.setKeybindSlots(Object.keys(kbinds).length)
     }
 });
 

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -1,0 +1,121 @@
+"use strict";
+import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback } from './utils.js';
+import { Locale, Popover } from './classes.js'
+
+
+const SIDE_NAVIGATION = document.querySelector(".side-navigation");
+const CONTENT_CONTAINER = document.querySelector(".content-container");
+const SEARCH_CONTAINER = document.querySelector(".search-container");
+const MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
+const FOOTER_TEXT = document.querySelector(".footer-text");
+
+window.addEventListener("load", async (e) => {
+    ExecuteNUICallback("NUI_READY", {}).finally(() => {})
+    const LOCALES = new Locale(); // We just need to init this after the everything is loaded.
+})
+
+document.addEventListener('popoverAction', (e) => {
+    const { action, button, emoteId, event } = e.detail;
+    switch (action) {
+        case 'groupemote':
+            break;
+        case 'placement':
+            break;
+        case 'keybind':
+            break;
+        case 'favorite':
+            break;
+    }
+});
+
+document.addEventListener('localesLoaded', (e) => {
+    // Handler for Right-click menu.
+    // Can we please have updated CEF in FiveM? I want my Popover API. --CritteR
+    /////////////////////////////////////////////////////////////////////////////////
+    const emotePopover = new Popover('.btn-emote', `
+        <p>/e somecommand</p>
+        <button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>
+        <button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>
+        <button class="popover-menu-item" data-action="keybind">${Locale.translate("btn_setkeybind")}</button>
+        <button class="popover-menu-item" data-action="favorite">${Locale.translate("btn_set_favorite")}</button>
+    `);
+})
+
+
+// Sidebar Logic. We just handle everything in the utils anyway, to keep this file tidy.
+// No, I will not stop over-commeting. Why do you ask?
+////////////////////////////////////////////////////////////////////////////////////
+SIDE_NAVIGATION.addEventListener("click", (e) => {
+    const TARGET = e.target;
+
+    if (TARGET && TARGET.dataset.action) {
+        HandleSidebarButtonPress(TARGET);
+        return;
+    }
+})
+
+MENUS.forEach((element) => {
+    element.addEventListener("mouseover", (e) => {
+        const TARGET = e.target;
+        if (!TARGET.dataset.emoteid) {
+            FOOTER_TEXT.innerHTML = "&nbsp;"
+            return;
+        }
+            
+        FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
+    })
+
+    element.addEventListener("focusin", (e) => {
+        const TARGET = e.target;
+        if (!TARGET.dataset.emoteid) {
+            FOOTER_TEXT.innerHTML = "&nbsp;"
+            return;
+        }
+            
+        FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
+    })
+
+    element.addEventListener("click", (e) => {
+        e.preventDefault();
+        const TARGET = e.target;
+        if (!TARGET.dataset.emoteid || !TARGET.dataset.emotetype) return;
+
+        ExecuteNUICallback("ROUTE_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype})
+    })
+})
+
+SEARCH_CONTAINER.addEventListener("submit", (e) => {
+    e.preventDefault();
+})
+
+
+window.addEventListener('message', (event) => {
+    if (event.data.type === 'OPEN_MENU') {
+        (event.data.value ? document.body.style.display = "flex" : document.body.style.display = "none")
+    }
+
+    if (event.data.type === 'LOAD_EMOTE_DATA') {
+        // event.data.emoteData && event.data.categoryToEmotes
+    }
+
+    if (event.data.type === 'BUILD_EMOTE_MENUS') {
+        // event.data
+        console.log(event.data)
+
+        Object.keys(event.data).forEach((key) => {
+            if (key !== "type" && key !== "keybinds") {
+                const EMOTES = CONTENT_CONTAINER.querySelector(`.${key}-menu`);
+                if (!EMOTES) return;
+                ClearHTMLContainer(`.${key}-menu`);
+                event.data[key].forEach((el) => {
+                    if (el) {
+                        EMOTES.insertAdjacentHTML("beforeend", `
+                            <button class="btn btn-${el.emoteType === "Emojis" ? "emoji" : "emote"} ${el.isFavorite ? "btn-emote-favorite" : ""}" data-emoteid="${el.id}" data-emoteType="${el.emoteType}">${el.label}</button>
+                            `)
+                    }
+                })
+            }
+        })
+    }
+});
+

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -65,7 +65,9 @@ function isElementVisible(element) {
     return element?.style?.display !== "none";
 }
 
-// TODO: There has to be a better way to write keyboard navigation, than this.
+// TODO:    There has to be a better way to write keyboard navigation, than this.
+//          Code is hardcoded to check the 3 spaces where buttons might be, and also hardcoded to handle it based on how the HTML looks for each.
+//          Ideally, this should automagically find the previous/next focusable item in the DOM, like how the normal [Tab] action does.
 function focusOnNextButton(currentButton, jumpAhead = false) {
     if (currentButton && currentButton.closest(".grid")) {
         const gridContainer = currentButton.closest(".grid");
@@ -75,7 +77,6 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
         let nextIndex = (currentIndex + step) % buttons.length;
         let attempts = 0;
         
-        // Skip hidden elements
         while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
             nextIndex = (nextIndex + 1) % buttons.length;
             attempts++;
@@ -129,7 +130,6 @@ function focusOnPreviousButton(currentButton, jumpAhead = false) {
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;
         
-        // Skip hidden elements
         while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
             nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
             attempts++;
@@ -147,7 +147,6 @@ function focusOnPreviousButton(currentButton, jumpAhead = false) {
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;
         
-        // Skip hidden elements
         while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
             nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
             attempts++;

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -25,6 +25,7 @@ document.addEventListener("keyup", (e) => {
         case "Backspace":
             if (!FOCUS_ELEMENT) return ExecuteNUICallback("CLOSE_MENU", {});
             if (FOCUS_ELEMENT === document.querySelector(".search-input") && document.querySelector(".search-input")?.value !== "") return;
+            if (FOCUS_ELEMENT.closest(".popover")) return;
 
             PlaySoundFrontend("BACK");
             if (FOCUS_ELEMENT.closest(".grid")) return document.querySelector(".btn-clear-search").focus();
@@ -67,13 +68,29 @@ function isElementVisible(element) {
 function focusOnNextButton(currentButton, jumpAhead = false) {
     if (currentButton && currentButton.closest(".grid")) {
         const gridContainer = currentButton.closest(".grid");
-        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote"));
+        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
         const currentIndex = buttons.indexOf(currentButton);
         const step = jumpAhead ? 10 : 1;
         let nextIndex = (currentIndex + step) % buttons.length;
         let attempts = 0;
         
         // Skip hidden elements
+        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+            nextIndex = (nextIndex + 1) % buttons.length;
+            attempts++;
+        }
+        
+        if (attempts < buttons.length) {
+            buttons[nextIndex]?.focus();
+        }
+    } else if (currentButton && currentButton.closest(".popover")) {
+        const gridContainer = currentButton.closest(".popover");
+        const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
+        const currentIndex = buttons.indexOf(currentButton);
+        const step = 1;
+        let nextIndex = (currentIndex + step) % buttons.length;
+        let attempts = 0;
+        
         while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
             nextIndex = (nextIndex + 1) % buttons.length;
             attempts++;
@@ -103,10 +120,28 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
 function focusOnPreviousButton(currentButton, jumpAhead = false) {
     if (currentButton && currentButton.closest(".grid")) {
         const gridContainer = currentButton.closest(".grid");
-        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote"));
+        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
         const currentIndex = buttons.indexOf(currentButton);
         if (currentIndex === 0) return SEARCH_BAR.focus();
         const step = jumpAhead ? 10 : 1;
+        let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
+        let attempts = 0;
+        
+        // Skip hidden elements
+        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+            nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
+            attempts++;
+        }
+        
+        if (attempts < buttons.length) {
+            buttons[nextIndex]?.focus();
+        }
+    } else if (currentButton && currentButton.closest(".popover")) {
+        const gridContainer = currentButton.closest(".popover");
+        const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
+        const currentIndex = buttons.indexOf(currentButton);
+        if (currentIndex === 0) return SEARCH_BAR.focus();
+        const step = 1;
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;
         

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -1,19 +1,52 @@
 "use strict";
 
-import { ExecuteNUICallback } from "./utils.js";
+import { ExecuteNUICallback, PlaySoundFrontend } from "./utils.js";
 
 const SEARCH_BAR = document.querySelector(".search-input");
 
-document.addEventListener("keyup", (e) => {
+document.addEventListener("keydown", (e) => {
+    switch (e.key) {
+        case "ArrowUp":
+        case "ArrowDown":
+        case "ArrowLeft":
+        case "ArrowRight":
+        case " ":
+            e.preventDefault();
+            break;
+        
+    }
+})
+
+// We use keyup to delay the action a bit. This helps us to not open the pause menu when closing the emote menu, for example.
+document.addEventListener("keyup", (e) => { 
+    const FOCUS_ELEMENT = document.activeElement;
     switch (e.key) {
         case "Escape":
-            const FOCUS_ELEMENT = document.activeElement;
+        case "Backspace":
             if (!FOCUS_ELEMENT) return ExecuteNUICallback("CLOSE_MENU", {});
+            if (FOCUS_ELEMENT === document.querySelector(".search-input") && document.querySelector(".search-input")?.value !== "") return;
 
-            if (FOCUS_ELEMENT.closest(".grid")) return SEARCH_BAR.focus();
+            PlaySoundFrontend("BACK");
+            if (FOCUS_ELEMENT.closest(".grid")) return document.querySelector(".btn-clear-search").focus();
             if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".btn-sidebar").focus();
             return ExecuteNUICallback("CLOSE_MENU", {});
             break;
+        case "ArrowDown":
+            focusOnNextButton(FOCUS_ELEMENT, e.shiftKey);
+            break;
+        case "ArrowUp":
+            focusOnPreviousButton(FOCUS_ELEMENT, e.shiftKey);
+            break;
+    }
+})
+
+document.addEventListener("scroll", (e) => e.preventDefault());
+
+document.addEventListener("mouseover", (e) => {
+    const TARGET = e.target
+    if (TARGET.nodeName === "BUTTON" || TARGET.nodeName === "INPUT") {
+        PlaySoundFrontend("NAV_UP_DOWN")
+        TARGET.focus();
     }
 })
 
@@ -24,3 +57,82 @@ SEARCH_BAR.addEventListener("focus", (e) => {
 SEARCH_BAR.addEventListener("blur", (e) => {
     ExecuteNUICallback("SEARCH_BAR_FOCUS", {isFocused: false});
 })
+
+
+function isElementVisible(element) {
+    return element?.style?.display !== "none";
+}
+
+// TODO: There has to be a better way to write keyboard navigation, than this.
+function focusOnNextButton(currentButton, jumpAhead = false) {
+    if (currentButton && currentButton.closest(".grid")) {
+        const gridContainer = currentButton.closest(".grid");
+        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote"));
+        const currentIndex = buttons.indexOf(currentButton);
+        const step = jumpAhead ? 10 : 1;
+        let nextIndex = (currentIndex + step) % buttons.length;
+        let attempts = 0;
+        
+        // Skip hidden elements
+        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+            nextIndex = (nextIndex + 1) % buttons.length;
+            attempts++;
+        }
+        
+        if (attempts < buttons.length) {
+            buttons[nextIndex]?.focus();
+        }
+    } else if (currentButton && currentButton.closest(".side-navigation")) {
+        const li = currentButton.closest("li");
+        const ulElement = li.parentElement;
+        const liElements = Array.from(ulElement.querySelectorAll("li"));
+        const currentIndex = liElements.indexOf(li);
+        const nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
+        const button = liElements[nextIndex]?.querySelector(".btn-sidebar");
+        button ? button?.focus() : ulElement.firstElementChild.querySelector(".btn-sidebar")?.focus();
+    } else if (currentButton && currentButton.closest(".search-container")) {
+        const gridContainer = currentButton.closest(".search-container");
+        const elements = Array.from(gridContainer.querySelectorAll("input"));
+        const currentIndex = elements.indexOf(currentButton);
+        const nextIndex = currentIndex + 1;
+        elements[nextIndex] ? elements[nextIndex]?.focus() : document.querySelector(".grid")?.querySelector(".btn-emote")?.focus();
+    }
+    PlaySoundFrontend("NAV_UP_DOWN");
+}
+
+function focusOnPreviousButton(currentButton, jumpAhead = false) {
+    if (currentButton && currentButton.closest(".grid")) {
+        const gridContainer = currentButton.closest(".grid");
+        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote"));
+        const currentIndex = buttons.indexOf(currentButton);
+        if (currentIndex === 0) return SEARCH_BAR.focus();
+        const step = jumpAhead ? 10 : 1;
+        let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
+        let attempts = 0;
+        
+        // Skip hidden elements
+        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+            nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
+            attempts++;
+        }
+        
+        if (attempts < buttons.length) {
+            buttons[nextIndex]?.focus();
+        }
+    } else if (currentButton && currentButton.closest(".side-navigation")) {
+        const li = currentButton.closest("li");
+        const ulElement = li.parentElement;
+        const liElements = Array.from(ulElement.querySelectorAll("li"));
+        const currentIndex = liElements.indexOf(li);
+        const nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
+        const button = liElements[nextIndex]?.querySelector(".btn");
+        button ? button?.focus() : ulElement.lastElementChild.querySelector(".btn-sidebar")?.focus();
+    } else if (currentButton && currentButton.closest(".search-container")) {
+        const gridContainer = currentButton.closest(".search-container");
+        const elements = Array.from(gridContainer.querySelectorAll("input"));
+        const currentIndex = elements.indexOf(currentButton);
+        const nextIndex = currentIndex - 1;
+        elements[nextIndex] ? elements[nextIndex]?.focus() : document.querySelector(".sidebar-button-active")?.querySelector(".btn-sidebar")?.focus();
+    }
+    PlaySoundFrontend("NAV_UP_DOWN");
+}

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { ExecuteNUICallback, PlaySoundFrontend } from "./utils.js";
+import { ExecuteNUICallback, PlaySoundFrontend, querySelectorVisible } from "./utils.js";
 
 const SEARCH_BAR = document.querySelector(".search-input");
 
@@ -28,8 +28,9 @@ document.addEventListener("keyup", (e) => {
             if (FOCUS_ELEMENT.closest(".popover")) return;
 
             PlaySoundFrontend("BACK");
+            if (FOCUS_ELEMENT.closest(".keybinds-menu")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             if (FOCUS_ELEMENT.closest(".grid")) return document.querySelector(".btn-clear-search").focus();
-            if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".btn-sidebar").focus();
+            if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             return ExecuteNUICallback("CLOSE_MENU", {});
             break;
         case "ArrowDown":
@@ -82,6 +83,7 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
         
         if (attempts < buttons.length) {
             buttons[nextIndex]?.focus();
+            buttons[nextIndex]?.scrollIntoView({block: "center"})
         }
     } else if (currentButton && currentButton.closest(".popover")) {
         const gridContainer = currentButton.closest(".popover");
@@ -112,7 +114,7 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
         const elements = Array.from(gridContainer.querySelectorAll("input"));
         const currentIndex = elements.indexOf(currentButton);
         const nextIndex = currentIndex + 1;
-        elements[nextIndex] ? elements[nextIndex]?.focus() : document.querySelector(".grid")?.querySelector(".btn-emote")?.focus();
+        elements[nextIndex] ? elements[nextIndex]?.focus() : querySelectorVisible(document.querySelector(".grid"))?.focus();
     }
     PlaySoundFrontend("NAV_UP_DOWN");
 }
@@ -135,12 +137,12 @@ function focusOnPreviousButton(currentButton, jumpAhead = false) {
         
         if (attempts < buttons.length) {
             buttons[nextIndex]?.focus();
+            buttons[nextIndex]?.scrollIntoView({block: "center"})
         }
     } else if (currentButton && currentButton.closest(".popover")) {
         const gridContainer = currentButton.closest(".popover");
         const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
         const currentIndex = buttons.indexOf(currentButton);
-        if (currentIndex === 0) return SEARCH_BAR.focus();
         const step = 1;
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -52,6 +52,25 @@ document.addEventListener("mouseover", (e) => {
     }
 })
 
+
+let _lastFocusedButton;
+document.addEventListener("focusin", (e) => {
+    const TARGET = e.target
+    if (TARGET === _lastFocusedButton) return;
+    if (TARGET.nodeName === "BUTTON" || TARGET.nodeName === "INPUT") {
+        _lastFocusedButton = TARGET;
+    }
+})
+
+function _refocusOnLastButton(e) {
+    if (e.target.nodeName !== "HTML" && e.target !== document.body) return;
+    if (document.activeElement === document.body) _lastFocusedButton?.focus();
+}
+
+document.addEventListener("click", _refocusOnLastButton)
+document.addEventListener("contextmenu", _refocusOnLastButton)
+
+
 SEARCH_BAR.addEventListener("focus", (e) => {
     ExecuteNUICallback("SEARCH_BAR_FOCUS", {isFocused: true});
 })

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import { ExecuteNUICallback } from "./utils.js";
+
+const SEARCH_BAR = document.querySelector(".search-input");
+
+document.addEventListener("keyup", (e) => {
+    switch (e.key) {
+        case "Escape":
+            const FOCUS_ELEMENT = document.activeElement;
+            if (!FOCUS_ELEMENT) return ExecuteNUICallback("CLOSE_MENU", {});
+
+            if (FOCUS_ELEMENT.closest(".grid")) return SEARCH_BAR.focus();
+            if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".btn-sidebar").focus();
+            return ExecuteNUICallback("CLOSE_MENU", {});
+            break;
+    }
+})
+
+SEARCH_BAR.addEventListener("focus", (e) => {
+    ExecuteNUICallback("SEARCH_BAR_FOCUS", {isFocused: true});
+})
+
+SEARCH_BAR.addEventListener("blur", (e) => {
+    ExecuteNUICallback("SEARCH_BAR_FOCUS", {isFocused: false});
+})

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -1,0 +1,74 @@
+"use strict";
+
+export function ClearHTMLContainer(elementClass) {
+    const ELEMENT = document.querySelector(elementClass);
+    let retval = 0;
+    if (ELEMENT) {
+        retval = ELEMENT.children.length;
+        ELEMENT.innerHTML = "" // Woah.
+    }
+    return retval;
+}
+
+export function HandleSidebarButtonPress(el) {
+    if (!el || !el.dataset.action) return;
+    const CONTENT_CONTAINER = document.querySelector(".content-container")
+    switch (el.dataset.action) {
+        case "openMenu":
+            const PREVIOUS_ACTIVE_BUTTON_CONTAINER = document.querySelector(".sidebar-button-active");
+            const PREVIOUS_ACTIVE_BUTTON = PREVIOUS_ACTIVE_BUTTON_CONTAINER.querySelector(".btn-sidebar");
+            if (el === PREVIOUS_ACTIVE_BUTTON) break;
+
+            if (PREVIOUS_ACTIVE_BUTTON_CONTAINER) {
+                PREVIOUS_ACTIVE_BUTTON_CONTAINER.classList.remove("sidebar-button-active");
+                CONTENT_CONTAINER.querySelectorAll(".grid").forEach((el) => {
+                    el.classList.remove("grid")
+                })
+            }
+                
+            const BUTTON_CONTAINER = el.closest(".sidebar-button-container")
+            if (BUTTON_CONTAINER) BUTTON_CONTAINER.classList.add("sidebar-button-active");
+            CONTENT_CONTAINER.querySelector(`.${el.dataset.menu}`)?.classList.add("grid");
+            // This is why people use frontend frameworks, I guess. -- CritteR
+            break;
+        case "cancelEmote":
+            const req = ExecuteNUICallback("CANCEL_EMOTE", {}).finally((retval) => {}) 
+            break;
+        default:
+            console.log(`What am I supposed to do with this action? (${el.dataset.action})`)
+            break;
+    }
+}
+
+export async function HandleLocales() {
+    const req = await ExecuteNUICallback("GET_LOCALES", {})
+    if (!req) {
+        console.log(req)
+        return {}
+    };
+    const LOCALES = await req.json()
+    if (!LOCALES || !LOCALES.data) return {};
+    document.querySelectorAll("[data-locale]").forEach((el) => {
+        // I love the JavaScript, hollyyyy.
+        if (LOCALES.data[el.dataset.locale]) {
+            if (el.hasAttribute("placeholder")) {
+                el.setAttribute("placeholder", LOCALES.data[el.dataset.locale])
+            } else {
+                el.textContent = LOCALES.data[el.dataset.locale]
+            }
+        }
+    })
+    return LOCALES.data;
+}
+
+export async function ExecuteNUICallback(callback, data) {
+    let retval = await fetch(`https://${GetParentResourceName()}/${callback}`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json; charset=UTF-8",
+			},
+			body: JSON.stringify(data),
+		});
+
+    return retval
+}

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -5,7 +5,7 @@ export function ClearHTMLContainer(elementClass) {
     let retval = 0;
     if (ELEMENT) {
         retval = ELEMENT.children.length;
-        ELEMENT.innerHTML = "" // Woah.
+        ELEMENT.innerHTML = "";
     }
     return retval;
 }
@@ -34,13 +34,12 @@ export function HandleSidebarButtonPress(el) {
 
             SEARCH_CONTAINER.classList.remove("hidden");
             SEARCH_CONTAINER.querySelector(".search-input").value = "";
-            HandleEmoteSearch(""); // hack to clear search. Sorry.
+            HandleEmoteSearch(""); // Bodge to clear search. Sorry.
             if (OPENED_MENU?.classList.contains("keybinds-menu")) {
                 SEARCH_CONTAINER.classList.add("hidden");
             }
 
             querySelectorVisible(OPENED_MENU)?.focus();
-            // This is why people use frontend frameworks, I guess. -- CritteR
             break;
         case "cancelEmote":
             const req = ExecuteNUICallback("CANCEL_EMOTE", {}).finally((retval) => {}) 
@@ -86,13 +85,12 @@ export async function HandleLocales() {
     const LOCALES = await req.json()
     if (!LOCALES || !LOCALES.data) return {};
     document.querySelectorAll("[data-locale]").forEach((el) => {
-        // I love the JavaScript, hollyyyy.
         if (LOCALES.data[el.dataset.locale]) {
             if (el.hasAttribute("placeholder")) {
                 el.setAttribute("placeholder", LOCALES.data[el.dataset.locale])
             } else {
                 el.innerHTML = LOCALES.data[el.dataset.locale]
-                //innerHTML for the sole purpose of allowing locales to contain <br> and stuff. Pretty much only for keybinds_description
+                //innerHTML for the sole purpose of allowing locales to contain html (like <br>). Pretty much only for the `keybinds_description` locale.
             }
         }
     })

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -17,7 +17,6 @@ export function HandleSidebarButtonPress(el) {
         case "openMenu":
             const PREVIOUS_ACTIVE_BUTTON_CONTAINER = document.querySelector(".sidebar-button-active");
             const PREVIOUS_ACTIVE_BUTTON = PREVIOUS_ACTIVE_BUTTON_CONTAINER.querySelector(".btn-sidebar");
-            if (el === PREVIOUS_ACTIVE_BUTTON) break;
 
             if (PREVIOUS_ACTIVE_BUTTON_CONTAINER) {
                 PREVIOUS_ACTIVE_BUTTON_CONTAINER.classList.remove("sidebar-button-active");
@@ -28,7 +27,9 @@ export function HandleSidebarButtonPress(el) {
                 
             const BUTTON_CONTAINER = el.closest(".sidebar-button-container")
             if (BUTTON_CONTAINER) BUTTON_CONTAINER.classList.add("sidebar-button-active");
-            CONTENT_CONTAINER.querySelector(`.${el.dataset.menu}`)?.classList.add("grid");
+            const OPENED_MENU = CONTENT_CONTAINER.querySelector(`.${el.dataset.menu}`)
+            OPENED_MENU?.classList.add("grid");
+            querySelectorVisible(OPENED_MENU)?.focus();
             // This is why people use frontend frameworks, I guess. -- CritteR
             break;
         case "cancelEmote":
@@ -38,6 +39,32 @@ export function HandleSidebarButtonPress(el) {
             console.log(`What am I supposed to do with this action? (${el.dataset.action})`)
             break;
     }
+}
+
+export function HandleEmoteSearch(search, menu = ".grid") {
+    const CONTENT_CONTAINER = document.querySelector(".content-container");
+    const searchValue = typeof search !== "undefined" ? search?.toLowerCase() : document.querySelector(".search-input").value.toLowerCase();
+    const gridElements = CONTENT_CONTAINER.querySelectorAll(menu);
+    
+    gridElements.forEach((grid) => {
+        const buttons = grid.querySelectorAll("[data-emoteid]");
+        buttons.forEach((button) => {
+            const emoteId = button.dataset.emoteid.toLowerCase();
+            button.style.display = emoteId.includes(searchValue) ? "" : "none";
+        })
+    })
+}
+
+export function querySelectorVisible(parent, query = ".btn") {
+    const elements = parent?.querySelectorAll(query);
+    let retval;
+    for (const el of elements) {
+        if (el?.style?.display !== "none") {
+            retval = el;
+            break;
+        }
+    }
+    return retval;
 }
 
 export async function HandleLocales() {
@@ -71,4 +98,12 @@ export async function ExecuteNUICallback(callback, data) {
 		});
 
     return retval
+}
+
+let playSoundAllowed = true;
+export function PlaySoundFrontend(soundName) {
+    if (!playSoundAllowed) return;
+    playSoundAllowed = false;
+    ExecuteNUICallback("PLAY_SOUND_FRONTEND", {soundName: "SELECT"});
+    setTimeout(() => {playSoundAllowed = true}, 100)
 }

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -12,7 +12,8 @@ export function ClearHTMLContainer(elementClass) {
 
 export function HandleSidebarButtonPress(el) {
     if (!el || !el.dataset.action) return;
-    const CONTENT_CONTAINER = document.querySelector(".content-container")
+    const CONTENT_CONTAINER = document.querySelector(".content-container");
+    const SEARCH_CONTAINER = document.querySelector(".search-container")
     switch (el.dataset.action) {
         case "openMenu":
             const PREVIOUS_ACTIVE_BUTTON_CONTAINER = document.querySelector(".sidebar-button-active");
@@ -29,6 +30,15 @@ export function HandleSidebarButtonPress(el) {
             if (BUTTON_CONTAINER) BUTTON_CONTAINER.classList.add("sidebar-button-active");
             const OPENED_MENU = CONTENT_CONTAINER.querySelector(`.${el.dataset.menu}`)
             OPENED_MENU?.classList.add("grid");
+            PlaySoundFrontend("SELECT")
+
+            SEARCH_CONTAINER.classList.remove("hidden");
+            SEARCH_CONTAINER.querySelector(".search-input").value = "";
+            HandleEmoteSearch(""); // hack to clear search. Sorry.
+            if (OPENED_MENU?.classList.contains("keybinds-menu")) {
+                SEARCH_CONTAINER.classList.add("hidden");
+            }
+
             querySelectorVisible(OPENED_MENU)?.focus();
             // This is why people use frontend frameworks, I guess. -- CritteR
             break;
@@ -70,7 +80,7 @@ export function querySelectorVisible(parent, query = ".btn") {
 export async function HandleLocales() {
     const req = await ExecuteNUICallback("GET_LOCALES", {})
     if (!req) {
-        console.log(req)
+        console.log("Bad locales callback: ", req)
         return {}
     };
     const LOCALES = await req.json()
@@ -81,7 +91,8 @@ export async function HandleLocales() {
             if (el.hasAttribute("placeholder")) {
                 el.setAttribute("placeholder", LOCALES.data[el.dataset.locale])
             } else {
-                el.textContent = LOCALES.data[el.dataset.locale]
+                el.innerHTML = LOCALES.data[el.dataset.locale]
+                //innerHTML for the sole purpose of allowing locales to contain <br> and stuff. Pretty much only for keybinds_description
             }
         }
     })
@@ -104,6 +115,6 @@ let playSoundAllowed = true;
 export function PlaySoundFrontend(soundName) {
     if (!playSoundAllowed) return;
     playSoundAllowed = false;
-    ExecuteNUICallback("PLAY_SOUND_FRONTEND", {soundName: "SELECT"});
+    ExecuteNUICallback("PLAY_SOUND_FRONTEND", {soundName: soundName});
     setTimeout(() => {playSoundAllowed = true}, 100)
 }

--- a/config.lua
+++ b/config.lua
@@ -102,7 +102,7 @@ Config = {
 
     -- Developer Tools
     CheckForUpdates = true,
-    DebugDisplay = true,
+    DebugDisplay = false,
 
     -- Emote Placement
     PlacementEnabled = true,

--- a/config.lua
+++ b/config.lua
@@ -102,7 +102,7 @@ Config = {
 
     -- Developer Tools
     CheckForUpdates = true,
-    DebugDisplay = false,
+    DebugDisplay = true,
 
     -- Emote Placement
     PlacementEnabled = true,

--- a/config.lua
+++ b/config.lua
@@ -115,7 +115,7 @@ Config = {
     RecoverEmotesAfterRagdoll = true, -- If true, the resource will attempt to recover emotes after being bumped / ragdolled. Doesn't work for all.
 
     -- NUI Menu
-    UseNUIMenu = true, -- If true, it will use the NUI menu, instead of the Scaleform one.
+    UseNUIMenu = true, -- If true, it will use the NUI menu, instead of the Scaleform one. NativeUI is still driving the emote data in the background.
 }
 
 -- Custom Categories: Define custom categories to organize emotes in the menu

--- a/config.lua
+++ b/config.lua
@@ -112,7 +112,10 @@ Config = {
     UseOldPropSpawning = false, -- Uses networked objects spawned client-side, for props. Only use this when you have issues spawning props.
 
     -- Recover Emotes after Ragdoll
-    RecoverEmotesAfterRagdoll = true -- If true, the resource will attempt to recover emotes after being bumped / ragdolled. Doesn't work for all.
+    RecoverEmotesAfterRagdoll = true, -- If true, the resource will attempt to recover emotes after being bumped / ragdolled. Doesn't work for all.
+
+    -- NUI Menu
+    UseNUIMenu = true, -- If true, it will use the NUI menu, instead of the Scaleform one.
 }
 
 -- Custom Categories: Define custom categories to organize emotes in the menu

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,10 +13,15 @@ dependencies {
     '/onesync'
 }
 
+ui_page('client/NUI/index.html')
+
 files {
     'conditionalanims.meta',
     'header.png',
-    'locales/*.lua'
+    'locales/*.lua',
+    'client/NUI/js/*.js',
+    'client/NUI/css/*.css',
+    'client/NUI/index.html',
 }
 
 -- Unlocks idle Animations from GTA:O when using motorcycles, dirt bikes, etc
@@ -47,6 +52,7 @@ client_scripts {
     'client/Emote.lua',
     'client/GroupEmote.lua',
     'client/EmoteMenu.lua',
+    'client/NUI/EmoteMenuNUI.lua',
     'client/Expressions.lua',
     'client/Handsup.lua',
     'client/Keybinds.lua',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -87,6 +87,8 @@ return {
     ['keybind_slot'] = "Emote Slot %i",
     ['registered_keybind'] = "Emote (~g~%s~s~) added to keybind ~b~%s~s~",
     ['cleared_keybind'] = "Emote Slot %i has been cleared!",
+    ['empty_slot'] = "Empty Slot",
+    ['keybind_description'] = "This menu is to help you visualize the emotes that you have connected to a keybind, and the control that is used. <br><br>You can modify the key bindings in the GTA settings.",
     -- Commands descriptions
     ['cancel_emote'] = "Cancel current emote",
     ['crouch'] = "Crouch",


### PR DESCRIPTION
This PR adds an entire new menu option for servers to use, allowing them to switch between NativeUI and NUI, using a config boolean.
The NUI menu mains to provide the same functionality and feel like NativeUI (menu usage without losing input, for example) while also improving the menu feel. 
As part of the new NUI, rpemotes now has a simple-to-use set of NUI callbacks, that can be used to interact with the resource. This means that servers can modify their NUI menu without digging into the Lua code.

## NUI Features:
* Menu is being built using the same functions as NativeUI, meaning that future changes to the emote data handling will reflect both menus.
* Menu uses the same locales as the rest of the resource. Servers that changed / added their locales will automagically see them in NUI.
* Only 2 new locale keys added (one to also fix a missing one in NativeUI).
* Header image uses the same file as NativeUI.
* Simple keyboard navigation without losing player control:
  * Up / Down arrows to move through the menu (Tab also left active).
    * Holding [Shift] will move faster through the menu / skip items.
  * Enter for selecting a button.
    * Holding [Shift] will open the popover menu instead.
  * Backspace / Escape to go back or exit the menu.
* Mouse navigation, by holding [Alt] while the menu is open (player loses control while being held, of course).
* Favorites, Group Emotes, Placement and Keybinds all work the same as NativeUI.
* Favorite emotes will show with a golden gradient everywhere on the menu.
* Same preview functionality as NativeUI.

## Quirks:
* Emote search works per-emote list in NUI. That's because I took a shortcut and just fitered the already shown emotes. This might need a better implementation later, that queries all emote types and shows them (in the same way as Favorites).
* Keyboard navigation gave me a hard time. It works, but the code is awful.
* Popover menu does everything inside the class itself. Ideally, we should have another event that listens for the right-click, and creates a new Popover there, so we can use cleaner code. Or maybe CFX should update the CEF already so I can use my beloved Popover API.

## Missing Features and Bad Implementations:
* The NUI menu doesn't have a button legend at the bottom of the page (to show the Shift / Alt / Arrow Keys movement).
* Popover menu for emotes shows a different button for eash "Set as Keybind" slot. This needs to be a list, especially for servers that use more than 6 slots.
* Keybinds menu isn't hidden, when keybinds are not enabled.
* When the NUI menu is open, we are blocking the player's cursor in the middle of the screen. This is not a problem in-game, but it is a problem when the player tries to Alt-Tab while the menu is open. That's because CFX decided it's cool to have a native that highjacks the player's cursor, even when the game is not in focus.

## Screenshots:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a52f3c3-b5e9-450c-b3a1-44c35e791fd2" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bc66e04b-30bf-49b2-809f-b1bfe1af07c0" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c5f904db-829f-47e3-a56d-ebd0b45fa725" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/aa95c7e0-c7e7-42b7-82b3-84eceb1ae762" />
