### PR TITLE
fix (Frameworks): Use `CanDoAction()` bridge function for pointing, binos and newscam

### DIFF
--- a/client/Binoculars.lua
+++ b/client/Binoculars.lua
@@ -31,6 +31,7 @@ end
 function UseBinocular()
     if IsPedSittingInAnyVehicle(PlayerPedId()) then return end
     if IsInActionWithErrorMessage({ IsUsingBinoculars = true }) then return end
+    if not CanDoAction() then return end
     IsUsingBinoculars = not IsUsingBinoculars
 
     if IsUsingBinoculars then

--- a/client/NewsCam.lua
+++ b/client/NewsCam.lua
@@ -33,6 +33,7 @@ end
 function UseNewscam()
     if IsPedSittingInAnyVehicle(PlayerPedId()) then return end
     if IsInActionWithErrorMessage({IsUsingNewscam = true }) then return end
+    if not CanDoAction() then return end
     IsUsingNewscam = not IsUsingNewscam
 
     if IsUsingNewscam then

--- a/client/Pointing.lua
+++ b/client/Pointing.lua
@@ -15,6 +15,7 @@ local function CanPlayerPoint()
         and not IsPedInjured(playerPed)
         and not IsPedInMeleeCombat(playerPed)
         and not IsPedRagdoll(playerPed)
+        and CanDoAction()
 end
 
 local function PointingStopped()


### PR DESCRIPTION
This PR aims to fix issues where "dead" players on frameworks such as QBCore or ESX would still be able to use pointing, binoculars or newscam. This happens because those frameworks don't actually kill the ped, but set it in a custom dead state, with a player animation.

## RCA:
Those systems did not use the `CanDoAction()` bridge function.

## Fix:
Use it.
