### PR TITLE
feat (NUI): Menu improvements and fixes

### DIFF
--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -28,6 +28,15 @@ local NUIEmoteType = {
     [EmoteType.EMOJI] = "emojis"
 }
 
+local keyList = {
+    { controlGroup = 2, key = 176, text = 'btn_select' },
+    { controlGroup = 2, keys = {176, 209}, text = 'btn_contextmenu'},
+    { controlGroup = 2, key = 177,  text = 'btn_back' },
+    { controlGroup = 2, keys = {172, 173}, text = 'btn_move'},
+    { controlGroup = 2, key = 209,  text = 'btn_move_faster' },
+    { key = 19,  text = 'btn_cursor' }
+}
+
 local function getEmojiFromCategoryName(str)
     -- Wild for-loop to find emojis in the string.
     for i, char in utf8.codes(str) do
@@ -225,7 +234,11 @@ end
 AddEventHandler("rpemotes:internal:handleNUIOpened", function()
     SendNUIMessage({type = "OPEN_MENU", value = true})
     SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
+
+    local scaleform_instructions = SetupButtons(keyList)
+
     while IsNuiFocused() do
+        DrawScaleformMovieFullscreen(scaleform_instructions, 255, 255, 255, 255)
         DisableControlAction(0,37,true)
         DisableControlAction(0,200,true)
         if IsControlJustPressed(0,19) then
@@ -247,5 +260,6 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
         Citizen.Wait(1)
     end
     CreatePreviewPed("", "")
+    SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
     SendNUIMessage({type = "OPEN_MENU", value = false})
 end)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -68,7 +68,16 @@ local NUIEmoteCategories = {
 
 RegisterNUICallback('NUI_READY', function(data, cb)
     nuiReady = true
-    cb({["ok"] = true})
+    local configForNUI = {
+        Keybinding = Config.Keybinding,
+        MenuPosition = Config.MenuPosition,
+        EmojiMenuEnabled = Config.EmojiMenuEnabled,
+        ExpressionsEnabled = Config.ExpressionsEnabled,
+        WalkingStylesEnabled = Config.WalkingStylesEnabled,
+        PlacementEnabled = Config.PlacementEnabled,
+        Search = Config.Search,
+    }
+    cb({["ok"] = true, ["config"] = configForNUI})
 end)
 
 RegisterNUICallback('CLOSE_MENU', function(data, cb)

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -99,6 +99,10 @@ body {
     font-size: var(--font-size-primary);
 }
 
+.align-left {
+    align-items: flex-start !important;
+}
+
 hr {
     border-color: var(--color-border);
     margin: 0.4rem 0;

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import { HandleLocales, querySelectorVisible } from "./utils.js";
+import { CONFIG } from "./main.js";
 
 export class Popover {
     _keybindSlots = 0;
@@ -55,13 +56,15 @@ export class Popover {
             if (!this.currentButton.classList.contains("btn-keybind")) {
                 if (data.emoteType && data.emoteType !== "Emojis" && data.emoteType !== "Expressions" && data.emoteType !== "Walks" && data.emoteType !== "Shared") {
                     popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="groupemote">${Locale.translate("btn_groupselect")}</button>`)
-                    popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>`)
+                    if (CONFIG.PlacementEnabled) popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="placement">${Locale.translate("btn_place")}</button>`)
                 }
                 popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="favorite">${data.isFavorite ? Locale.translate("btn_remove_favorite") : Locale.translate("btn_set_favorite")}</button>`)
 
                 //TODO: This needs to be a HTML list.
-                for (let i = 1; i <= Popover._keybindSlots; i++) {
-                    popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="${i}">${Locale.translate("btn_setkeybind")} (${i})</button>`)
+                if (CONFIG.Keybinding) {
+                    for (let i = 1; i <= Popover._keybindSlots; i++) {
+                        popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item keybind-popover" data-action="set-keybind" data-slotid="${i}">${Locale.translate("btn_setkeybind")} (${i})</button>`)
+                    }
                 }
             } else {
                 popover.insertAdjacentHTML("beforeend", `<button class="popover-menu-item" data-action="clear-keybind">${Locale.translate("btn_delkeybind")}</button>`)

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -90,11 +90,17 @@ function _setupMenuEventListeners(MENUS) {
 
                 let _previewData = {}
                 if (TARGET.dataset.emotetype === "Expressions") _previewData = {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}
-                ExecuteNUICallback("PREVIEW_EMOTE", _previewData)
+                if (sendPreviewRequest) {
+                    sendPreviewRequest = false
+                    ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
+                }
                 return;
             }
 
-            if (sendPreviewRequest) ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
+            if (sendPreviewRequest) {
+                sendPreviewRequest = false
+                ExecuteNUICallback("PREVIEW_EMOTE", {emoteName: TARGET.dataset.emoteid, emoteType: TARGET.dataset.emotetype}).finally(() => sendPreviewRequest = true)
+            }
 
             FOOTER_TEXT.textContent = `/${TARGET.closest(".walkstyles-menu") ? "walk" : "e"} ${TARGET.dataset.emoteid}`
         })

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -11,9 +11,22 @@ let MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
 const FOOTER_TEXT = document.querySelector(".footer-text");
 
 let EMOTE_TYPE_ICONS = {}
+export let CONFIG;
 
 window.addEventListener("load", async (e) => {
-    ExecuteNUICallback("NUI_READY", {}).finally(() => {})
+
+    ExecuteNUICallback("NUI_READY", {}).then( async (res) => {
+        const response = await res.json();
+        if (!response.config) return;
+        CONFIG = response.config;
+
+        if (!CONFIG.Search) SEARCH_CONTAINER.classList.add("hidden");
+        if (!CONFIG.EmojiMenuEnabled) document.querySelector('[data-menu="emojis-menu"]')?.parentElement?.remove();
+        if (!CONFIG.ExpressionsEnabled) document.querySelector('[data-menu="moods-menu"]')?.parentElement?.remove();
+        if (!CONFIG.WalkingStylesEnabled) document.querySelector('[data-menu="walkstyles-menu"]')?.parentElement?.remove();
+        if (!CONFIG.Keybinding) document.querySelector('[data-menu="keybinds-menu"]')?.parentElement?.remove();
+        if (CONFIG.MenuPosition === "left") document.body.classList.add("align-left");
+    })
     const LOCALES = new Locale(); // We just need to init this after the everything is loaded. The class statics will handle everything.
 })
 

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import { ExecuteNUICallback, PlaySoundFrontend, querySelectorVisible } from "./utils.js";
+import { CONFIG } from "./main.js";
 
 const SEARCH_BAR = document.querySelector(".search-input");
 
@@ -28,7 +29,7 @@ document.addEventListener("keyup", (e) => {
             if (FOCUS_ELEMENT.closest(".popover")) return;
 
             PlaySoundFrontend("BACK");
-            if (FOCUS_ELEMENT.closest(".keybinds-menu")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
+            if (FOCUS_ELEMENT.closest(".keybinds-menu") || (FOCUS_ELEMENT.closest(".content-container") && !CONFIG.Search) ) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             if (FOCUS_ELEMENT.closest(".grid")) return document.querySelector(".btn-clear-search").focus();
             if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             return ExecuteNUICallback("CLOSE_MENU", {});

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -1,4 +1,5 @@
 "use strict";
+import { CONFIG } from "./main.js";
 
 export function ClearHTMLContainer(elementClass) {
     const ELEMENT = document.querySelector(elementClass);
@@ -32,11 +33,13 @@ export function HandleSidebarButtonPress(el) {
             OPENED_MENU?.classList.add("grid");
             PlaySoundFrontend("SELECT")
 
-            SEARCH_CONTAINER.classList.remove("hidden");
-            SEARCH_CONTAINER.querySelector(".search-input").value = "";
-            HandleEmoteSearch(""); // Bodge to clear search. Sorry.
-            if (OPENED_MENU?.classList.contains("keybinds-menu")) {
-                SEARCH_CONTAINER.classList.add("hidden");
+            if (CONFIG.Search) {
+                SEARCH_CONTAINER.classList.remove("hidden");
+                SEARCH_CONTAINER.querySelector(".search-input").value = "";
+                HandleEmoteSearch(""); // Bodge to clear search. Sorry.
+                if (OPENED_MENU?.classList.contains("keybinds-menu")) {
+                    SEARCH_CONTAINER.classList.add("hidden");
+                }
             }
 
             querySelectorVisible(OPENED_MENU)?.focus();

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -310,10 +310,13 @@ function SetupButtons(button)
     for i, btn in pairs(button) do
         PushScaleformMovieFunction(scaleform, "SET_DATA_SLOT")
         PushScaleformMovieFunctionParameterInt(i - 1)
-        ScaleformMovieMethodAddParamPlayerNameString(GetControlInstructionalButton(0, btn.key, true))
-        BeginTextCommandScaleformString("STRING")
-        AddTextComponentScaleform(Translate(btn.text))
-        EndTextCommandScaleformString()
+        if btn.key then
+            PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(btn.controlGroup or 0, btn.key, true))
+        elseif btn.keys then
+            PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(btn.controlGroup or 0, btn.keys[1], true))
+            PushScaleformMovieMethodParameterButtonName(GetControlInstructionalButton(btn.controlGroup or 0, btn.keys[2], true))
+        end
+        PushScaleformMovieFunctionParameterString(Translate(btn.text))
         PopScaleformMovieFunctionVoid()
     end
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -112,4 +112,9 @@ return {
     ['btn_remove_favorite'] = "Remove Favorite",
     ['addedtofavorites'] = "Emote (~g~%s~s~) added to favorites!",
     ['removedfromfavorites'] = "Emote (~g~%s~s~) removed from favorites!",
+    -- NUI-specific keybinds
+    ['btn_move'] = "Move",
+    ['btn_contextmenu'] = "More options",
+    ['btn_cursor'] = "(Hold) Toggle Cursor",
+    ['btn_move_faster'] = "(Hold) Move Faster",
 }


### PR DESCRIPTION
This PR adds a couple of fixes and improvements to the NUI menu.

## Changes:
* Added instructional buttons and locale keys for them.
* Fixes ped preview not waiting for a preview emote to finish before starting another one. This hopefully fixes instances where multiple preview peds would spawn.
* Fixes the NUI menu not using config values for menu placement, and various toggles like Search, Expressions, Walks, etc.

 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2331b64f-8cf4-48e1-b026-5ac06eb1db99" />