### PR TITLE
fix (NUI): Multiple fixes and QoL

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -208,7 +208,7 @@ local EMOTE_PREFIX = {
     [EmoteType.PROP_EMOTES] = "📦 ",
 }
 
-local function shouldShowEmojiMenu()
+function ShouldShowEmojiMenu()
     if not Config.EmojiMenuEnabled then return false end
     if not Config.EmojiMenuAnimalsOnly then return true end
 
@@ -938,7 +938,7 @@ function OpenEmoteMenu()
 
     if placementState == PlacementState.PREVIEWING or placementState == PlacementState.WALKING then return end
 
-    local shouldHaveEmojiMenu = shouldShowEmojiMenu()
+    local shouldHaveEmojiMenu = ShouldShowEmojiMenu()
     local hasEmojiMenu = subMenus["emojis"] ~= nil
 
     if hasEmojiMenu ~= shouldHaveEmojiMenu then
@@ -1123,7 +1123,7 @@ function InitMenu()
     if Config.ExpressionsEnabled then
         addFaceMenu(mainMenu)
     end
-    if shouldShowEmojiMenu() then
+    if ShouldShowEmojiMenu() then
         addEmojiMenu(mainMenu)
     end
 

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -612,6 +612,29 @@ local function addEmoteMenu(menu)
     end
 end
 
+function SearchEmotes(input)
+    local results = {}
+    for emoteName, emoteData in pairs(EmoteData) do
+        if matchesSearchTerm(emoteName, emoteData, input) then
+            -- Check model compatibility
+            if not CachedPlayerModel or IsModelCompatible(CachedPlayerModel, emoteName) then
+                results[#results + 1] = { table = emoteData.emoteType, name = emoteName, data = emoteData }
+            end
+        end
+    end
+
+    if Config.SharedEmotesEnabled then
+        for emoteName, emoteData in pairs(SharedEmoteData) do
+            if matchesSearchTerm(emoteName, emoteData, input) then
+                results[#results + 1] = { table = EmoteType.SHARED, name = emoteName, data = emoteData }
+            end
+        end
+    end
+    table.sort(results, function(a, b) return a.name < b.name end)
+
+    return results
+end
+
 if Config.Search then
     function EmoteMenuSearch(lastMenu)
         ClosePedMenu()
@@ -625,7 +648,7 @@ if Config.Search then
         end
         _menuPool:RefreshIndex()
 
-    AddTextEntry("PM_NAME_CHALL", Translate('searchinputtitle'))
+        AddTextEntry("PM_NAME_CHALL", Translate('searchinputtitle'))
         DisplayOnscreenKeyboard(1, "PM_NAME_CHALL", "", "", "", "", "", 30)
         while UpdateOnscreenKeyboard() == 0 do
             DisableAllControlActions(0)
@@ -634,32 +657,13 @@ if Config.Search then
         local input = GetOnscreenKeyboardResult()
         if not input then return end
 
-        local results = {}
-        for emoteName, emoteData in pairs(EmoteData) do
-            if matchesSearchTerm(emoteName, emoteData, input) then
-                -- Check model compatibility
-                if not CachedPlayerModel or IsModelCompatible(CachedPlayerModel, emoteName) then
-                    results[#results + 1] = { table = emoteData.emoteType, name = emoteName, data = emoteData }
-                end
-            end
-        end
-
-        if Config.SharedEmotesEnabled then
-            for emoteName, emoteData in pairs(SharedEmoteData) do
-                if matchesSearchTerm(emoteName, emoteData, input) then
-                    results[#results + 1] = { table = EmoteType.SHARED, name = emoteName, data = emoteData }
-                end
-            end
-        end
-
+        local results = SearchEmotes(input)
         if #results <= 0 then
             SimpleNotify(string.format(Translate('searchnoresult')..' ~r~%s~w~', input))
-            return
         end
 
         local searchMenu = _menuPool:AddSubMenu(lastMenu, string.format('%s '..Translate('searchmenudesc')..' ~r~%s~w~', #results, input), "", true, true)
 
-        table.sort(results, function(a, b) return a.name < b.name end)
         for index, result in pairs(results) do
             local desc
             if result.table == EmoteType.SHARED then

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -112,7 +112,17 @@ end)
 
 RegisterNUICallback('ROUTE_EMOTE', function(data, cb)
     if data.type == "emote" then
-        RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
+        if data.emoteName == "_reset" then
+            if data.emoteType == EmoteType.WALKS then
+                ResetWalk()
+                DeleteResourceKvp("walkstyle")
+            elseif data.emoteType == EmoteType.EXPRESSIONS then
+                DeleteResourceKvp(EmoteType.EXPRESSIONS)
+                ClearFacialIdleAnimOverride(PlayerPedId())
+            end
+        else
+            RouteEmoteToFunction(data.emoteName, data.emoteType, 1)
+        end
     elseif data.type == "groupemote" then
         ToggleNUIMenu() -- Important to close first. Group emote request blocks the thread until you actually start the request.
         OnGroupEmoteRequest(data.emoteName)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -29,12 +29,18 @@ local NUIEmoteType = {
     [EmoteType.EMOJI] = "emojis"
 }
 
-local keyList = {
+local keyListKeyboard = {
     { controlGroup = 2, key = 176, text = 'btn_select' },
     { controlGroup = 2, keys = {176, 209}, text = 'btn_contextmenu'},
     { controlGroup = 2, key = 177,  text = 'btn_back' },
     { controlGroup = 2, keys = {172, 173}, text = 'btn_move'},
     { controlGroup = 2, key = 209,  text = 'btn_move_faster' },
+    { key = 19,  text = 'btn_cursor' }
+}
+
+local keyListMouse = {
+    { controlGroup = 2, key = 223, text = 'btn_select' },
+    { controlGroup = 2, key = 225, text = 'btn_contextmenu'},
     { key = 19,  text = 'btn_cursor' }
 }
 
@@ -261,7 +267,7 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
     SendNUIMessage({type = "OPEN_MENU", value = true})
     SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
 
-    local scaleform_instructions = SetupButtons(keyList)
+    local scaleform_instructions = SetupButtons(keyListKeyboard)
 
     while IsNuiFocused() do
         DrawScaleformMovieFullscreen(scaleform_instructions, 255, 255, 255, 255)
@@ -270,6 +276,8 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
         if IsControlJustPressed(0,19) then
             SetNuiFocus(true, true)
             SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = true})
+            SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
+            scaleform_instructions = SetupButtons(keyListMouse)
         end
         if IsControlPressed(0,19) then
             DisableControlAction(0,1,true)
@@ -282,6 +290,8 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
         if IsControlJustReleased(0,19) then
             SetNuiFocus(true, false)
             SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
+            SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
+            scaleform_instructions = SetupButtons(keyListKeyboard)
         end
         Citizen.Wait(1)
     end

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -1,4 +1,5 @@
 local nuiReady = false
+local initialDataLoaded = false
 
 
 -- The NUI logic is designed to run *on top* of the existing NativeUI logic, since that menu already does all the data handling that we need.
@@ -68,6 +69,7 @@ local NUIEmoteCategories = {
 
 RegisterNUICallback('NUI_READY', function(data, cb)
     nuiReady = true
+    DebugPrint("[ NUI READY ]")
     local configForNUI = {
         Keybinding = Config.Keybinding,
         MenuPosition = Config.MenuPosition,
@@ -78,6 +80,12 @@ RegisterNUICallback('NUI_READY', function(data, cb)
         Search = Config.Search,
     }
     cb({["ok"] = true, ["config"] = configForNUI})
+end)
+
+RegisterNUICallback('INITIAL_DATA_LOADED', function(data, cb)
+    initialDataLoaded = true
+    DebugPrint("[ NUI CATEGORIES LOADED ]")
+    cb({["ok"] = true})
 end)
 
 RegisterNUICallback('CLOSE_MENU', function(data, cb)
@@ -205,8 +213,7 @@ function AddEmoteToNUIQueue(data)
 end
 
 AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
-    while not nuiReady do Citizen.Wait(10) end
-
+    while not nuiReady and not initialDataLoaded do Citizen.Wait(10) end
     SendNUIMessage(dataForMenu)
     dataForMenu = {
         type = "BUILD_EMOTE_MENUS",

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -231,17 +231,9 @@ end
 AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
     while not nuiReady and not initialDataLoaded do Citizen.Wait(10) end
     SendNUIMessage(dataForMenu)
-    dataForMenu = {
-        type = "BUILD_EMOTE_MENUS",
-        ["emotes"] = {},
-        ["sharedEmotes"] = {},
-        ["propEmotes"] = {},
-        ["danceEmotes"] = {},
-        ["walkStyles"] = {},
-        ["moods"] = {},
-        ["emojis"] = {},
-        ["favorites"] = {}
-    }
+    for key, val in pairs(dataForMenu) do
+        dataForMenu[key] = {}
+    end
 end)
 
 AddEventHandler("rpemotes:internal:sendKeybindsDataToNUI", function(binds)
@@ -264,7 +256,8 @@ function ToggleNUIMenu()
 end
 
 AddEventHandler("rpemotes:internal:handleNUIOpened", function()
-    SendNUIMessage({type = "OPEN_MENU", value = true})
+    local _showEmoji = ShouldShowEmojiMenu()
+    SendNUIMessage({type = "OPEN_MENU", value = true, shouldShowEmojiMenu = _showEmoji})
     SendNUIMessage({type = "TOGGLE_CURSOR_INPUT", value = false})
 
     local scaleform_instructions = SetupButtons(keyListKeyboard)
@@ -293,9 +286,9 @@ AddEventHandler("rpemotes:internal:handleNUIOpened", function()
             SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
             scaleform_instructions = SetupButtons(keyListKeyboard)
         end
-        Citizen.Wait(1)
+        Wait(1)
     end
     CreatePreviewPed("", "")
     SetScaleformMovieAsNoLongerNeeded(scaleform_instructions)
-    SendNUIMessage({type = "OPEN_MENU", value = false})
+    SendNUIMessage({type = "OPEN_MENU", value = false, shouldShowEmojiMenu = _showEmoji})
 end)

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -1,5 +1,6 @@
 local nuiReady = false
 local initialDataLoaded = false
+local localesLoaded = false
 
 
 -- The NUI logic is designed to run *on top* of the existing NativeUI logic, since that menu already does all the data handling that we need.
@@ -91,6 +92,12 @@ end)
 RegisterNUICallback('INITIAL_DATA_LOADED', function(data, cb)
     initialDataLoaded = true
     DebugPrint("[ NUI CATEGORIES LOADED ]")
+    cb({["ok"] = true})
+end)
+
+RegisterNUICallback('LOCALES_LOADED', function(data, cb)
+    localesLoaded = true
+    DebugPrint("[ NUI LOCALES LOADED ]")
     cb({["ok"] = true})
 end)
 
@@ -211,8 +218,7 @@ AddEventHandler("rpemotes:internal:loadEmoteDataToNUI", function(EmoteData, Cate
         dataForMenu[htmlClass] = {}
     end
 
-
-    while not nuiReady do Citizen.Wait(10) end
+    while not nuiReady or not localesLoaded do Citizen.Wait(10) end
     SendNUIMessage({type = "LOAD_EMOTE_DATA", emoteData = EmoteData, categoryToEmotes = CategoryToEmotes, emoteCategories = NUIEmoteCategories, emoteTypeIcons = EmoteTypeEmoji})
 end)
 
@@ -229,7 +235,7 @@ function AddEmoteToNUIQueue(data)
 end
 
 AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
-    while not nuiReady and not initialDataLoaded do Citizen.Wait(10) end
+    while not nuiReady or not initialDataLoaded do Citizen.Wait(10) end
     SendNUIMessage(dataForMenu)
     for key, val in pairs(dataForMenu) do
         dataForMenu[key] = {}
@@ -237,7 +243,7 @@ AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
 end)
 
 AddEventHandler("rpemotes:internal:sendKeybindsDataToNUI", function(binds)
-    while not nuiReady do Citizen.Wait(10) end
+    while not nuiReady or not initialDataLoaded do Citizen.Wait(10) end
 
     SendNUIMessage({
         type = "BUILD_KEYBINDS_MENU",

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -199,6 +199,19 @@ RegisterNUICallback('PREVIEW_EMOTE', function(data, cb)
     cb({["ok"] = true, ["done"] = returnValue})
 end)
 
+RegisterNUICallback('SEARCH_EMOTES', function(data, cb)
+    local retval = {}
+    if data.searchTerm ~= nil then
+        retval = SearchEmotes(data.searchTerm)
+    end
+    --
+    -- Sending results data from `SearchEmotes()` without encoding causes FiveM to crash.
+    -- Not sure why, but I assume it's related to JSON encoding / decoding.
+    -- Doing it manually seems to work fine.
+    --
+    cb({["ok"] = true, ["emotes"] = json.encode(retval)})
+end)
+
 
 RegisterNUICallback('PLAY_SOUND_FRONTEND', function(data, cb)
     PlaySoundFrontend(-1, data.soundName, "HUD_FRONTEND_DEFAULT_SOUNDSET", true)

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -20,12 +20,23 @@
     --color-btn-popover-bg: rgba(62, 62, 62, 1);
     --color-btn-border: #1d1d1d;
     --color-btn-hover: #4f4f4f;
+
+    --color-scrollbar: #1589d8;
+    --color-scrollbar-hover: #3badf8;
+
     --color-accent-primary: #1589d8;
     --color-accent-primary-hover: #3badf8;
     --color-accent-secondary: #d84c15;
     --color-accent-secondary-hover: #ff8251;
     --color-accent-favorite: #ffd700;
     --color-accent-favorite-hover: #ffe96c;
+
+    --border-radius-menu: 1rem;
+    --border-radius-search-bar: 1rem;
+    --border-radius-btn-sidebar: 1rem;
+    --border-radius-btn-sidebar-hover: 0px;
+    --border-radius-btn-emote: 0px;
+    --border-radius-btn-emote-hover: 0px;
 
     --font-size-primary: 1.6rem;
 }
@@ -39,6 +50,21 @@ img,
 /* FiveM's CEF doesn't support standard CSS scrollbar styling :D */
 .invisible-scrollbar::-webkit-scrollbar {
   display: none;
+}
+
+::-webkit-scrollbar,
+::-webkit-scrollbar:horizontal {
+	width: 0.5rem;
+	height: 0.5rem;
+}
+::-webkit-scrollbar-track {
+	background: #f1f1f100;
+}
+::-webkit-scrollbar-thumb {
+	background: var(--color-scrollbar);
+}
+::-webkit-scrollbar-thumb:hover {
+	background: var(--color-scrollbar-hover);
 }
 
 .menu {
@@ -116,7 +142,7 @@ hr {
     color: var(--color-text-primary);
     height: 60vh;
     overflow: auto;
-    border-radius: 1rem;
+    border-radius: var(--border-radius-menu);
 }
 
 .header-container {
@@ -140,7 +166,7 @@ hr {
     background-color: var(--color-btn-bg);
     color: var(--color-text-primary);
     border: none;
-    border-radius: 1rem;
+    border-radius: var(--border-radius-search-bar);
     padding: 0 1rem;
 }
 
@@ -210,6 +236,7 @@ hr {
 }
 .sidebar-button-active button:hover, .sidebar-button-active button:focus-visible {
     background-color: var(--color-accent-primary-hover);
+    border-radius: var(--border-radius-btn-sidebar-hover);
 }
 .sidebar-button-active span {
     color: var(--color-accent-primary);
@@ -219,6 +246,12 @@ hr {
     width: 4.2rem;
     height: 4.2rem;
     margin: 0.5rem 0.5rem;
+    border-radius: var(--border-radius-btn-sidebar);
+    transition: all 200ms;
+}
+
+.btn-sidebar:hover, .btn-sidebar:focus-visible {
+    border-radius: var(--border-radius-btn-sidebar-hover);
 }
 
 .btn-sidebar-label {
@@ -257,7 +290,12 @@ hr {
 
 .btn-emote, .btn-emoji {
     height: 3.6rem;
-    border-radius: 1rem;
+    border-radius: var(--border-radius-btn-emote);
+    transition: all 200ms;
+}
+
+.btn-emote:hover, .btn-emoji:hover, .btn-emote:focus-visible, .btn-emoji:focus-visible {
+    border-radius: var(--border-radius-btn-emote-hover);
 }
 
 .btn-emote-favorite {

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -26,8 +26,8 @@
 
     --color-accent-primary: #1589d8;
     --color-accent-primary-hover: #3badf8;
-    --color-accent-secondary: #d84c15;
-    --color-accent-secondary-hover: #ff8251;
+    --color-accent-secondary: rgba(62, 62, 62, 1);
+    --color-accent-secondary-hover: #d84c15;
     --color-accent-favorite: #ffd700;
     --color-accent-favorite-hover: #ffe96c;
 
@@ -175,6 +175,15 @@ hr {
     height: 3.2rem;
     border: none !important;
     border-radius: 100% !important;
+}
+
+.btn-style-reset {
+    background-color: var(--color-accent-secondary) !important;
+    margin-bottom: 1rem;
+    grid-column: 1 / -1;
+}
+.btn-style-reset:hover, .btn-style-reset:focus-visible {
+    background-color: var(--color-accent-secondary-hover) !important;
 }
 
 .menu-container {

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -72,6 +72,7 @@ img,
     display: none;
     width: 100%;
     overflow-y: auto;
+    padding: 1rem;
 }
 
 .grid {
@@ -160,6 +161,7 @@ hr {
     display: flex;
     gap: 0.5rem;
     padding: 0 0.5rem;
+    padding-top: 1rem;
 }
 
 .search-input {
@@ -281,7 +283,7 @@ hr {
     flex-direction: column;
     gap: 2rem;
     margin-left: 5.4rem;
-    padding: 1rem;
+    /* padding: 1rem; */
     flex-grow: 1;
     width: 100%;
     overflow-x: hidden;
@@ -305,7 +307,7 @@ hr {
     transition: all 200ms;
 }
 
-.doublecolumn .btn-emote {
+.btn-emote {
     padding-left: 1rem;
     text-align: left;
 }
@@ -355,6 +357,10 @@ hr {
 .keybind-bind-text {
     color: var(--color-accent-primary);
     font-weight: 600;
+}
+
+.keybind-description {
+    white-space: pre-line;
 }
 
 

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -210,15 +210,24 @@ hr {
     max-width: 5.2rem;
     overflow-x: hidden;
     overflow-y: auto;
-    scrollbar-width: none;
     background-color: var(--color-bg-sidebar);
     transition: all 200ms;
     flex-wrap: nowrap;
 }
 
+.side-navigation::-webkit-scrollbar {
+    scrollbar-width: thin;
+    display: none;
+}
+
 .side-navigation:hover, .side-navigation:has(button:focus-visible) {
     max-width: 80%;
     flex-grow: 1;
+}
+
+.side-navigation:hover::-webkit-scrollbar, .side-navigation:has(button:focus-visible)::-webkit-scrollbar {
+    scrollbar-width: thin;
+    display: inherit;
 }
 
 .btn {

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -178,7 +178,9 @@ hr {
     width: 3.2rem;
     height: 3.2rem;
     border: none !important;
-    border-radius: 100% !important;
+    border-radius: var(--border-radius-search-bar) !important;
+    text-align: center;
+    text-justify: center;
 }
 
 .btn-style-reset {

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -49,7 +49,8 @@ img,
 
 /* FiveM's CEF doesn't support standard CSS scrollbar styling :D */
 .invisible-scrollbar::-webkit-scrollbar {
-  display: none;
+    scrollbar-width: thin;
+    display: none;
 }
 
 ::-webkit-scrollbar,
@@ -70,6 +71,7 @@ img,
 .menu {
     display: none;
     width: 100%;
+    overflow-y: auto;
 }
 
 .grid {

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -8,7 +8,7 @@
 
 :root {
     --color-bg-primary: rgba(46, 46, 46, 1);
-    --color-bg-sidebar: rgba(17, 17, 17, 1);
+    --color-bg-sidebar: rgba(46, 46, 46, 1);
 
     --color-text-primary: rgba(239, 239, 239, 1);
     --color-text-secondary: rgba(138, 138, 138, 1);
@@ -31,9 +31,9 @@
     --color-accent-favorite: #ffd700;
     --color-accent-favorite-hover: #ffe96c;
 
-    --border-radius-menu: 1rem;
-    --border-radius-search-bar: 1rem;
-    --border-radius-btn-sidebar: 1rem;
+    --border-radius-menu: 5px;
+    --border-radius-search-bar: 0px;
+    --border-radius-btn-sidebar: 0px;
     --border-radius-btn-sidebar-hover: 0px;
     --border-radius-btn-emote: 0px;
     --border-radius-btn-emote-hover: 0px;

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -303,6 +303,11 @@ hr {
     transition: all 200ms;
 }
 
+.doublecolumn .btn-emote {
+    padding-left: 1rem;
+    text-align: left;
+}
+
 .btn-emote:hover, .btn-emoji:hover, .btn-emote:focus-visible, .btn-emoji:focus-visible {
     border-radius: var(--border-radius-btn-emote-hover);
 }

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -46,7 +46,7 @@
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="moods-menu">🎭</button>
                         <span class="btn-sidebar-label" data-locale="moods">Moods</span>
                     </li>
-                    <li class="sidebar-button-container">
+                    <li class="sidebar-button-container emoji-sidebar">
                         <button class="btn btn-sidebar" data-action="openMenu" data-menu="emojis-menu">😀</button>
                         <span class="btn-sidebar-label" data-locale="emojis">Emojis</span>
                     </li>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -52,7 +52,7 @@
                     </li>
                 </ul>
             </nav>
-            <section class="content-container invisible-scrollbar">
+            <section class="content-container">
                 <form class="search-container">
                     <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search..." data-locale="searchemotes">
                     <input type="reset" value="x" class="btn btn-clear-search"></input>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -13,7 +13,7 @@
     <script type="module" src="js/navigation.js" defer></script>
     <script type="module" src="js/main.js" defer></script>
 </head>
-<body style="display: flex;">
+<body style="display: none;">
     <div class="main-container noselect">
         <header class="header-container">
             <img src="/header.png" alt="RP Emotes" class="header-image">
@@ -75,6 +75,7 @@
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
                 <article class="menu moods-menu singlecolumn">
+                    <button class="btn btn-emote btn-style-reset" data-emoteid="_reset" data-emotetype="_null" data-locale="normalreset"></button>
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
                 <article class="menu emojis-menu triplecolumn">

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -20,7 +20,7 @@
         </header>
         <main class="menu-container" tabindex="-1">
             <nav class="side-navigation invisible-scrollbar">
-                <ul>
+                <ul class="btn-list">
                     <li class="sidebar-button-container">
                         <button id="cancel-emote-btn" class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
                         <label for="cancel-emote-btn" class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</label>
@@ -53,32 +53,32 @@
                 </ul>
             </nav>
             <section class="content-container">
-                <form class="search-container">
+                <form class="search-container btn-list">
                     <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search..." data-locale="searchemotes">
                     <input type="reset" value="x" class="btn btn-clear-search"></input>
                 </form>
-                <article class="menu menu-anchor emotes-menu grid doublecolumn">
+                <article class="menu menu-anchor emotes-menu grid doublecolumn btn-list">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
                 <!-- Custom Emote Groups added here -->
                 <article class="menu keybinds-menu singlecolumn">
-                    <ul class="keybinds-list">
+                    <ul class="keybinds-list btn-list">
                         <li>
                             <p class="keybind-description" data-locale="keybind_description"></p>
                         </li>
                     </ul>
                 </article>
-                <article class="menu favorites-menu doublecolumn">
+                <article class="menu favorites-menu doublecolumn btn-list">
                     <button class="btn btn-emote btn-emote-favorite" data-emoteid="emote1">Emote 1</button>
                 </article>
-                <article class="menu walkstyles-menu doublecolumn">
+                <article class="menu walkstyles-menu doublecolumn btn-list">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
-                <article class="menu moods-menu singlecolumn">
+                <article class="menu moods-menu singlecolumn btn-list">
                     <button class="btn btn-emote btn-style-reset" data-emoteid="_reset" data-emotetype="_null" data-locale="normalreset"></button>
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>
-                <article class="menu emojis-menu triplecolumn">
+                <article class="menu emojis-menu triplecolumn btn-list">
                     <button class="btn btn-emoji" data-emoji="emote1">😀</button>
                 </article>
             </section>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -19,11 +19,15 @@
             <img src="/header.png" alt="RP Emotes" class="header-image">
         </header>
         <main class="menu-container" tabindex="-1">
-            <nav class="side-navigation invisible-scrollbar">
+            <nav class="side-navigation">
                 <ul class="btn-list">
                     <li class="sidebar-button-container">
                         <button id="cancel-emote-btn" class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
                         <label for="cancel-emote-btn" class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</label>
+                    </li>
+                    <li class="sidebar-button-container">
+                        <button id="keybinds-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="search-menu">🔍</button>
+                        <label for="keybinds-menu-btn" class="btn-sidebar-label" data-locale="searchemotes">Search</label>
                     </li>
                     <li class="sidebar-button-container sidebar-button-active sidebar-button-anchor">
                         <button id="emotes-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
@@ -57,6 +61,9 @@
                     <input type="text" class="search-input" id="emote_search" autocomplete="rpemotes" placeholder="Search..." data-locale="searchemotes">
                     <input type="reset" value="x" class="btn btn-clear-search"></input>
                 </form>
+                <article class="menu search-menu doublecolumn btn-list">
+                    <p class="keybind-description" data-locale="searchemotes"></p>
+                </article>
                 <article class="menu menu-anchor emotes-menu grid doublecolumn btn-list">
                     <button class="btn btn-emote" data-emoteid="emote1">Emote 1</button>
                 </article>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -13,7 +13,7 @@
     <script type="module" src="js/navigation.js" defer></script>
     <script type="module" src="js/main.js" defer></script>
 </head>
-<body style="display: none;">
+<body style="display: flex;">
     <div class="main-container noselect">
         <header class="header-container">
             <img src="/header.png" alt="RP Emotes" class="header-image">
@@ -22,33 +22,33 @@
             <nav class="side-navigation invisible-scrollbar">
                 <ul>
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
-                        <span class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</span>
+                        <button id="cancel-emote-btn" class="btn btn-sidebar btn-cancel-emote" data-action="cancelEmote">🚷</button>
+                        <label for="cancel-emote-btn" class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</label>
                     </li>
                     <li class="sidebar-button-container sidebar-button-active sidebar-button-anchor">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
-                        <span class="btn-sidebar-label" data-locale="emotes">Emotes</span>
+                        <button id="emotes-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>
+                        <label for="emotes-menu-btn" class="btn-sidebar-label" data-locale="emotes">Emotes</label>
                     </li>
                     <!-- Custom Emote Groups added here -->
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="keybinds-menu">🔢</button>
-                        <span class="btn-sidebar-label" data-locale="keybinds">Keybinds</span>
+                        <button id="keybinds-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="keybinds-menu">🔢</button>
+                        <label for="keybinds-menu-btn" class="btn-sidebar-label" data-locale="keybinds">Keybinds</label>
                     </li>
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="favorites-menu">🌟</button>
-                        <span class="btn-sidebar-label" data-locale="favorites">Favorites</span>
+                        <button id="favorites-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="favorites-menu">🌟</button>
+                        <label for="favorites-menu-btn" class="btn-sidebar-label" data-locale="favorites">Favorites</label>
                     </li>
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="walkstyles-menu">🚶🏻‍♂️</button>
-                        <span class="btn-sidebar-label" data-locale="walkstyles">Walk Styles</span>
+                        <button id="walkstyles-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="walkstyles-menu">🚶🏻‍♂️</button>
+                        <label for="walkstyles-menu-btn" class="btn-sidebar-label" data-locale="walkstyles">Walk Styles</label>
                     </li>
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="moods-menu">🎭</button>
-                        <span class="btn-sidebar-label" data-locale="moods">Moods</span>
+                        <button id="moods-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="moods-menu">🎭</button>
+                        <label for="moods-menu-btn" class="btn-sidebar-label" data-locale="moods">Moods</label>
                     </li>
                     <li class="sidebar-button-container emoji-sidebar">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="emojis-menu">😀</button>
-                        <span class="btn-sidebar-label" data-locale="emojis">Emojis</span>
+                        <button id="emojis-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="emojis-menu">😀</button>
+                        <label for="emojis-menu-btn" class="btn-sidebar-label" data-locale="emojis">Emojis</label>
                     </li>
                 </ul>
             </nav>

--- a/client/NUI/index.html
+++ b/client/NUI/index.html
@@ -26,8 +26,8 @@
                         <label for="cancel-emote-btn" class="btn-sidebar-label" data-locale="cancelemote">Cancel Emote</label>
                     </li>
                     <li class="sidebar-button-container">
-                        <button id="keybinds-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="search-menu">🔍</button>
-                        <label for="keybinds-menu-btn" class="btn-sidebar-label" data-locale="searchemotes">Search</label>
+                        <button id="search-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="search-menu">🔍</button>
+                        <label for="search-menu-btn" class="btn-sidebar-label" data-locale="searchemotes">Search</label>
                     </li>
                     <li class="sidebar-button-container sidebar-button-active sidebar-button-anchor">
                         <button id="emotes-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="emotes-menu">🎬</button>

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -23,6 +23,10 @@ export class Popover {
             if (event.target.closest(this.triggerSelector)) {
                 e.preventDefault();
                 this.currentButton = event.target.closest(this.triggerSelector);
+                if (this.currentButton.classList.contains("btn-style-reset")) {
+                    this.currentButton = null;
+                    return;
+                }
                 this.show(event);
             }
         });

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -149,4 +149,17 @@ export class Locale {
         if (Locale.LOCALES[key]) return Locale.LOCALES[key];
         return String(key);
     }
+
+    static setLocaleStrings() {
+        document.querySelectorAll("[data-locale]").forEach((el) => {
+            if (Locale.LOCALES[el.dataset.locale]) {
+                if (el.hasAttribute("placeholder")) {
+                    el.setAttribute("placeholder", Locale.LOCALES[el.dataset.locale])
+                } else {
+                    el.textContent = Locale.LOCALES[el.dataset.locale]
+                    el.textContent = el.textContent.replace("\n", "\u000D\u000A")
+                }
+            }
+        })
+    }
 }

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -53,7 +53,7 @@ export class Popover {
         }
 
         const popover = document.createElement('div');
-        popover.className = 'popover';
+        popover.className = 'popover btn-list';
         document.body.appendChild(popover);
 
         if (data.emoteId) {

--- a/client/NUI/js/classes.js
+++ b/client/NUI/js/classes.js
@@ -160,6 +160,10 @@ export class Locale {
                     el.textContent = el.textContent.replace("\n", "\u000D\u000A")
                 }
             }
+            if (el.nodeName === "LABEL") {
+                const btn = document.getElementById(el.htmlFor)
+                if (btn) el.textContent = el.textContent.replace(btn.textContent, "");
+            }
         })
     }
 }

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -156,6 +156,7 @@ window.addEventListener('message', (event) => {
     if (event.data.type === 'OPEN_MENU') {
         (event.data.value ? document.body.style.display = "flex" : document.body.style.display = "none")
         document.querySelector(".btn-sidebar").focus();
+        event.data.shouldShowEmojiMenu ? document.querySelector(".emoji-sidebar")?.classList.remove("hidden") : document.querySelector(".emoji-sidebar")?.classList.add("hidden")
     }
 
     if (event.data.type === 'TOGGLE_CURSOR_INPUT') {

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -187,6 +187,7 @@ window.addEventListener('message', (event) => {
         })
         MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
         _setupMenuEventListeners(MENUS);
+        ExecuteNUICallback("INITIAL_DATA_LOADED", {})
     }
 
     if (event.data.type === 'BUILD_EMOTE_MENUS') {

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -12,6 +12,7 @@ const FOOTER_TEXT = document.querySelector(".footer-text");
 
 let EMOTE_TYPE_ICONS = {}
 export let CONFIG;
+export let UsingMouse = false;
 
 window.addEventListener("load", async (e) => {
 
@@ -154,6 +155,7 @@ window.addEventListener('message', (event) => {
 
     if (event.data.type === 'TOGGLE_CURSOR_INPUT') {
         (event.data.value ? document.body.classList.remove("no-cursor") : document.body.classList.add("no-cursor"))
+        UsingMouse = !document.body.classList.contains("no-cursor");
     }
 
     if (event.data.type === 'LOAD_EMOTE_DATA') {

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -196,10 +196,16 @@ window.addEventListener('message', (event) => {
                 const EMOTES = CONTENT_CONTAINER.querySelector(`.${key}-menu`);
                 if (!EMOTES) return;
                 ClearHTMLContainer(`.${key}-menu`);
+                if (key==="moods" || key==="walkstyles") {
+                    // Add the (Clear Mood) button here. Nightmares for future maintainers.
+                    EMOTES.insertAdjacentHTML("beforeend", `
+                        <button class="btn btn-emote btn-style-reset" data-emoteid="_reset" data-emotetype="${event.data[key][0].emoteType}" data-locale="normalreset"></button>
+                        `)
+                }
                 event.data[key].forEach((el) => {
                     if (el) {
                         EMOTES.insertAdjacentHTML("beforeend", `
-                            <button class="btn btn-emote ${el.isFavorite ? "btn-emote-favorite" : ""} ${el.emoteType === "Emojis" ? "noto-color-emoji-regular" : ""}" data-emoteid="${el.emoteName}" data-emoteType="${el.emoteType}" data-label="${el.label}">${el.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[el.emoteType]+" " : ""}${el.label}</button>
+                            <button class="btn btn-emote ${el.isFavorite ? "btn-emote-favorite" : ""} ${el.emoteType === "Emojis" ? "noto-color-emoji-regular" : ""}" data-emoteid="${el.emoteName}" data-emotetype="${el.emoteType}" data-label="${el.label}">${el.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[el.emoteType]+" " : ""}${el.label}</button>
                             `)
                     }
                 })

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -137,6 +137,11 @@ function _setupMenuEventListeners(MENUS) {
 SEARCH_CONTAINER.addEventListener("submit", (e) => {
     e.preventDefault();
     HandleEmoteSearch();
+    querySelectorVisible(document.querySelector(".grid"))?.focus();
+})
+
+SEARCH_CONTAINER.addEventListener("reset", (e) => {
+    HandleEmoteSearch("");
 })
 
 

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -175,8 +175,8 @@ window.addEventListener('message', (event) => {
             SIDEBAR_ANCHOR.insertAdjacentHTML("afterend",
                 `
                     <li class="sidebar-button-container">
-                        <button class="btn btn-sidebar" data-action="openMenu" data-menu="${emoteCategories[key].id}-menu">${emoteCategories[key].icon}</button>
-                        <span class="btn-sidebar-label">${key}</span>
+                        <button id="${emoteCategories[key].id}-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="${emoteCategories[key].id}-menu">${emoteCategories[key].icon}</button>
+                        <label for="${emoteCategories[key].id}-menu-btn" class="btn-sidebar-label">${key}</label>
                     </li>
                 `);
 

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -73,6 +73,7 @@ document.addEventListener('localesLoaded', (e) => {
     // All logic is done through the class, sadly. Sends a `popoverAction` custom event when a button is used.
     //////////////////////////////////////////////////////////////////////////////////////////////////////////
     const emotePopover = new Popover('.btn-emote');
+    ExecuteNUICallback("LOCALES_LOADED", {})
 })
 
 SIDE_NAVIGATION.addEventListener("click", (e) => {
@@ -216,6 +217,7 @@ window.addEventListener('message', (event) => {
             const ELEMENTS = Array.from(document.querySelectorAll(`[data-emoteid="${emote.emoteName}"]`));
             ELEMENTS.forEach((el) => el?.classList.add("btn-emote-favorite"));
         })
+        Locale.setLocaleStrings();
     }
 
     if (event.data.type === "BUILD_KEYBINDS_MENU") {

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -183,7 +183,7 @@ window.addEventListener('message', (event) => {
 
             MENU_ANCHOR.insertAdjacentHTML("afterend",
                 `
-                <article class="menu ${emoteCategories[key].id}-menu doublecolumn">Hiii
+                <article class="menu ${emoteCategories[key].id}-menu doublecolumn btn-list">Hiii
                 </article>
                 `)
         })

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -177,7 +177,7 @@ window.addEventListener('message', (event) => {
                 `
                     <li class="sidebar-button-container">
                         <button id="${emoteCategories[key].id}-menu-btn" class="btn btn-sidebar" data-action="openMenu" data-menu="${emoteCategories[key].id}-menu">${emoteCategories[key].icon}</button>
-                        <label for="${emoteCategories[key].id}-menu-btn" class="btn-sidebar-label">${key}</label>
+                        <label for="${emoteCategories[key].id}-menu-btn" class="btn-sidebar-label" data-locale="${key}">${key}</label>
                     </li>
                 `);
 

--- a/client/NUI/js/main.js
+++ b/client/NUI/js/main.js
@@ -1,5 +1,5 @@
 "use strict";
-import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback, PlaySoundFrontend, HandleEmoteSearch, querySelectorVisible } from './utils.js';
+import { ClearHTMLContainer, HandleSidebarButtonPress, ExecuteNUICallback, PlaySoundFrontend, HandleEmoteFilter, HandleEmoteSearch, querySelectorVisible } from './utils.js';
 import { Locale, Popover } from './classes.js'
 
 
@@ -10,7 +10,7 @@ const SEARCH_BAR = SEARCH_CONTAINER.querySelector(".search-input");
 let MENUS = CONTENT_CONTAINER.querySelectorAll(".menu");
 const FOOTER_TEXT = document.querySelector(".footer-text");
 
-let EMOTE_TYPE_ICONS = {}
+export let EMOTE_TYPE_ICONS = {}
 export let CONFIG;
 export let UsingMouse = false;
 
@@ -21,7 +21,10 @@ window.addEventListener("load", async (e) => {
         if (!response.config) return;
         CONFIG = response.config;
 
-        if (!CONFIG.Search) SEARCH_CONTAINER.classList.add("hidden");
+        if (!CONFIG.Search) {
+            SEARCH_CONTAINER.classList.add("hidden");
+            document.querySelector('[data-menu="search-menu"]')?.parentElement?.remove();
+        }
         if (!CONFIG.EmojiMenuEnabled) document.querySelector('[data-menu="emojis-menu"]')?.parentElement?.remove();
         if (!CONFIG.ExpressionsEnabled) document.querySelector('[data-menu="moods-menu"]')?.parentElement?.remove();
         if (!CONFIG.WalkingStylesEnabled) document.querySelector('[data-menu="walkstyles-menu"]')?.parentElement?.remove();
@@ -135,20 +138,25 @@ function _setupMenuEventListeners(MENUS) {
     })
 }
 
-SEARCH_CONTAINER.addEventListener("submit", (e) => {
+SEARCH_CONTAINER.addEventListener("submit", async (e) => {
     e.preventDefault();
-    HandleEmoteSearch();
+    if (document.querySelector(".search-menu.grid")) {
+        await HandleEmoteSearch();
+    } else {
+        await HandleEmoteFilter();
+    }
     querySelectorVisible(document.querySelector(".grid"))?.focus();
 })
 
 SEARCH_CONTAINER.addEventListener("reset", (e) => {
-    HandleEmoteSearch("");
+    HandleEmoteFilter("");
 })
 
 
 let lastSearchInputValue = ""
 SEARCH_BAR.addEventListener("input", (e) => {
-    if (SEARCH_BAR.value !== lastSearchInputValue) HandleEmoteSearch();
+    if (document.querySelector(".search-menu.grid")) return;
+    if (SEARCH_BAR.value !== lastSearchInputValue) HandleEmoteFilter();
     lastSearchInputValue = SEARCH_BAR.value
 })
 

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -13,9 +13,8 @@ document.addEventListener("keydown", (e) => {
         case "ArrowLeft":
         case "ArrowRight":
         case " ":
-            e.preventDefault();
+            if (document.activeElement !== SEARCH_BAR) e.preventDefault();
             break;
-        
     }
 })
 
@@ -23,15 +22,15 @@ document.addEventListener("keydown", (e) => {
 document.addEventListener("keyup", (e) => { 
     const FOCUS_ELEMENT = document.activeElement;
     switch (e.key) {
-        case "Escape":
         case "Backspace":
+            if (FOCUS_ELEMENT === document.querySelector(".search-input")) break;
+        case "Escape":
             if (!FOCUS_ELEMENT) return ExecuteNUICallback("CLOSE_MENU", {});
-            if (FOCUS_ELEMENT === document.querySelector(".search-input") && document.querySelector(".search-input")?.value !== "") return;
             if (FOCUS_ELEMENT.closest(".popover")) return;
 
             PlaySoundFrontend("BACK");
             if (FOCUS_ELEMENT.closest(".keybinds-menu") || (FOCUS_ELEMENT.closest(".content-container") && !CONFIG.Search) ) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
-            if (FOCUS_ELEMENT.closest(".grid")) return document.querySelector(".btn-clear-search").focus();
+            if (FOCUS_ELEMENT.closest(".grid") && SEARCH_BAR.value !== "") return document.querySelector(".btn-clear-search").focus();
             if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             return ExecuteNUICallback("CLOSE_MENU", {});
             break;

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -2,6 +2,7 @@
 
 import { ExecuteNUICallback, PlaySoundFrontend, querySelectorVisible } from "./utils.js";
 import { CONFIG } from "./main.js";
+import { UsingMouse } from "./main.js";
 
 const SEARCH_BAR = document.querySelector(".search-input");
 
@@ -34,19 +35,35 @@ document.addEventListener("keyup", (e) => {
             if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             return ExecuteNUICallback("CLOSE_MENU", {});
             break;
+        case "PageDown":
         case "ArrowDown":
             focusOnNextButton(FOCUS_ELEMENT, e.shiftKey);
             break;
+        case "PageUp":
         case "ArrowUp":
             focusOnPreviousButton(FOCUS_ELEMENT, e.shiftKey);
             break;
     }
 })
 
+document.addEventListener("wheel", (e) => {
+    if (!UsingMouse) {
+        const JUMPS = e.deltaY / 100; // 1 = down, -1 = up. 2,3,4... means that the scroll is too fast, so we jump ahead.
+        const FOCUS_ELEMENT = document.activeElement;
+        // console.log(UsingMouse, JUMPS)
+        if (JUMPS > 0) {
+            focusOnNextButton(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
+        } else {
+            focusOnPreviousButton(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
+        }
+    };
+});
+
 document.addEventListener("scroll", (e) => e.preventDefault());
 
 document.addEventListener("mouseover", (e) => {
     const TARGET = e.target
+    if (TARGET === SEARCH_BAR) return; 
     if (TARGET.nodeName === "BUTTON" || TARGET.nodeName === "INPUT") {
         PlaySoundFrontend("NAV_UP_DOWN")
         TARGET.focus();
@@ -88,12 +105,12 @@ function isElementVisible(element) {
 // TODO:    There has to be a better way to write keyboard navigation, than this.
 //          Code is hardcoded to check the 3 spaces where buttons might be, and also hardcoded to handle it based on how the HTML looks for each.
 //          Ideally, this should automagically find the previous/next focusable item in the DOM, like how the normal [Tab] action does.
-function focusOnNextButton(currentButton, jumpAhead = false) {
+function focusOnNextButton(currentButton, jumpAhead = false, jumps = 1) {
     if (currentButton && currentButton.closest(".grid")) {
         const gridContainer = currentButton.closest(".grid");
         const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
         const currentIndex = buttons.indexOf(currentButton);
-        const step = jumpAhead ? 10 : 1;
+        const step = jumpAhead ? 10 : jumps;
         let nextIndex = (currentIndex + step) % buttons.length;
         let attempts = 0;
         
@@ -110,7 +127,7 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
         const gridContainer = currentButton.closest(".popover");
         const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
         const currentIndex = buttons.indexOf(currentButton);
-        const step = 1;
+        const step = jumps;
         let nextIndex = (currentIndex + step) % buttons.length;
         let attempts = 0;
         
@@ -127,7 +144,7 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
+        const nextIndex = (currentIndex + (jumpAhead ? 2 : jumps)) % liElements.length;
         const button = liElements[nextIndex]?.querySelector(".btn-sidebar");
         button ? button?.focus() : ulElement.firstElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {
@@ -140,13 +157,13 @@ function focusOnNextButton(currentButton, jumpAhead = false) {
     PlaySoundFrontend("NAV_UP_DOWN");
 }
 
-function focusOnPreviousButton(currentButton, jumpAhead = false) {
+function focusOnPreviousButton(currentButton, jumpAhead = false, jumps = 1) {
     if (currentButton && currentButton.closest(".grid")) {
         const gridContainer = currentButton.closest(".grid");
         const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
         const currentIndex = buttons.indexOf(currentButton);
         if (currentIndex === 0) return SEARCH_BAR.focus();
-        const step = jumpAhead ? 10 : 1;
+        const step = jumpAhead ? 10 : jumps;
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;
         
@@ -163,7 +180,7 @@ function focusOnPreviousButton(currentButton, jumpAhead = false) {
         const gridContainer = currentButton.closest(".popover");
         const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
         const currentIndex = buttons.indexOf(currentButton);
-        const step = 1;
+        const step = jumps;
         let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
         let attempts = 0;
         
@@ -180,7 +197,7 @@ function focusOnPreviousButton(currentButton, jumpAhead = false) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
+        const nextIndex = (currentIndex - (jumpAhead ? 2 : jumps)) % liElements.length;
         const button = liElements[nextIndex]?.querySelector(".btn");
         button ? button?.focus() : ulElement.lastElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -98,7 +98,7 @@ SEARCH_BAR.addEventListener("blur", (e) => {
 
 
 function isElementVisible(element) {
-    return element?.style?.display !== "none";
+    return !element?.classList.contains("hidden")
 }
 
 // TODO:    There has to be a better way to write keyboard navigation, than this.
@@ -143,7 +143,16 @@ function focusOnNextButton(currentButton, jumpAhead = false, jumps = 1) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
+        let nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
+        let attempts = 0;
+
+        console.log(isElementVisible(liElements[nextIndex]), liElements[nextIndex])
+
+        while (!isElementVisible(liElements[nextIndex]) && attempts < liElements.length) {
+            nextIndex = (nextIndex + 1) % liElements.length;
+            attempts++;
+        }
+
         const button = liElements[nextIndex]?.querySelector(".btn-sidebar");
         button ? button?.focus() : ulElement.firstElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {
@@ -196,7 +205,13 @@ function focusOnPreviousButton(currentButton, jumpAhead = false, jumps = 1) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
+        let nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
+        let attempts = 0;
+
+        while (!isElementVisible(liElements[nextIndex]) && attempts < liElements.length) {
+            nextIndex = (nextIndex - 1) % liElements.length;
+            attempts++;
+        }
         const button = liElements[nextIndex]?.querySelector(".btn");
         button ? button?.focus() : ulElement.lastElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -146,8 +146,6 @@ function focusOnNextButton(currentButton, jumpAhead = false, jumps = 1) {
         let nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
         let attempts = 0;
 
-        console.log(isElementVisible(liElements[nextIndex]), liElements[nextIndex])
-
         while (!isElementVisible(liElements[nextIndex]) && attempts < liElements.length) {
             nextIndex = (nextIndex + 1) % liElements.length;
             attempts++;

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -143,7 +143,7 @@ function focusOnNextButton(currentButton, jumpAhead = false, jumps = 1) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex + (jumpAhead ? 2 : jumps)) % liElements.length;
+        const nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
         const button = liElements[nextIndex]?.querySelector(".btn-sidebar");
         button ? button?.focus() : ulElement.firstElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {
@@ -196,7 +196,7 @@ function focusOnPreviousButton(currentButton, jumpAhead = false, jumps = 1) {
         const ulElement = li.parentElement;
         const liElements = Array.from(ulElement.querySelectorAll("li"));
         const currentIndex = liElements.indexOf(li);
-        const nextIndex = (currentIndex - (jumpAhead ? 2 : jumps)) % liElements.length;
+        const nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
         const button = liElements[nextIndex]?.querySelector(".btn");
         button ? button?.focus() : ulElement.lastElementChild.querySelector(".btn-sidebar")?.focus();
     } else if (currentButton && currentButton.closest(".search-container")) {

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -36,11 +36,18 @@ document.addEventListener("keyup", (e) => {
             break;
         case "PageDown":
         case "ArrowDown":
-            focusOnNextButton(FOCUS_ELEMENT, e.shiftKey);
+            navigateDown(FOCUS_ELEMENT, e.shiftKey, 1, true);
             break;
         case "PageUp":
         case "ArrowUp":
-            focusOnPreviousButton(FOCUS_ELEMENT, e.shiftKey);
+            navigateUp(FOCUS_ELEMENT, e.shiftKey, 1, true);
+            break;
+        
+        case "ArrowLeft":
+            navigateUp(FOCUS_ELEMENT, e.shiftKey);
+            break;
+        case "ArrowRight":
+            navigateDown(FOCUS_ELEMENT, e.shiftKey);
             break;
     }
 })
@@ -49,11 +56,10 @@ document.addEventListener("wheel", (e) => {
     if (!UsingMouse) {
         const JUMPS = e.deltaY / 100; // 1 = down, -1 = up. 2,3,4... means that the scroll is too fast, so we jump ahead.
         const FOCUS_ELEMENT = document.activeElement;
-        // console.log(UsingMouse, JUMPS)
         if (JUMPS > 0) {
-            focusOnNextButton(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
+            navigateDown(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
         } else {
-            focusOnPreviousButton(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
+            navigateUp(FOCUS_ELEMENT, e.shiftKey, Math.abs(JUMPS));
         }
     };
 });
@@ -61,14 +67,14 @@ document.addEventListener("wheel", (e) => {
 document.addEventListener("scroll", (e) => e.preventDefault());
 
 document.addEventListener("mouseover", (e) => {
-    const TARGET = e.target
+    let TARGET = e.target
     if (TARGET === SEARCH_BAR) return; 
-    if (TARGET.nodeName === "BUTTON" || TARGET.nodeName === "INPUT") {
+    if (TARGET.nodeName === "BUTTON" || TARGET.nodeName === "INPUT" || TARGET.nodeName === "LABEL") {
+        if (TARGET.nodeName === "LABEL") TARGET = document.getElementById(TARGET.htmlFor);
         PlaySoundFrontend("NAV_UP_DOWN")
         TARGET.focus();
     }
 })
-
 
 let _lastFocusedButton;
 document.addEventListener("focusin", (e) => {
@@ -98,126 +104,65 @@ SEARCH_BAR.addEventListener("blur", (e) => {
 
 
 function isElementVisible(element) {
-    return !element?.classList.contains("hidden")
+    const display = element && window.getComputedStyle(element).getPropertyValue("display") === "none";
+    return !display;
 }
 
-// TODO:    There has to be a better way to write keyboard navigation, than this.
-//          Code is hardcoded to check the 3 spaces where buttons might be, and also hardcoded to handle it based on how the HTML looks for each.
-//          Ideally, this should automagically find the previous/next focusable item in the DOM, like how the normal [Tab] action does.
-function focusOnNextButton(currentButton, jumpAhead = false, jumps = 1) {
-    if (currentButton && currentButton.closest(".grid")) {
-        const gridContainer = currentButton.closest(".grid");
-        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
-        const currentIndex = buttons.indexOf(currentButton);
-        const step = jumpAhead ? 10 : jumps;
-        let nextIndex = (currentIndex + step) % buttons.length;
-        let attempts = 0;
-        
-        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
-            nextIndex = (nextIndex + 1) % buttons.length;
-            attempts++;
-        }
-        
-        if (attempts < buttons.length) {
-            buttons[nextIndex]?.focus();
-            buttons[nextIndex]?.scrollIntoView({block: "center"})
-        }
-    } else if (currentButton && currentButton.closest(".popover")) {
-        const gridContainer = currentButton.closest(".popover");
-        const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
-        const currentIndex = buttons.indexOf(currentButton);
-        const step = jumps;
-        let nextIndex = (currentIndex + step) % buttons.length;
-        let attempts = 0;
-        
-        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
-            nextIndex = (nextIndex + 1) % buttons.length;
-            attempts++;
-        }
-        
-        if (attempts < buttons.length) {
-            buttons[nextIndex]?.focus();
-        }
-    } else if (currentButton && currentButton.closest(".side-navigation")) {
-        const li = currentButton.closest("li");
-        const ulElement = li.parentElement;
-        const liElements = Array.from(ulElement.querySelectorAll("li"));
-        const currentIndex = liElements.indexOf(li);
-        let nextIndex = (currentIndex + (jumpAhead ? 2 : 1)) % liElements.length;
-        let attempts = 0;
-
-        while (!isElementVisible(liElements[nextIndex]) && attempts < liElements.length) {
-            nextIndex = (nextIndex + 1) % liElements.length;
-            attempts++;
-        }
-
-        const button = liElements[nextIndex]?.querySelector(".btn-sidebar");
-        button ? button?.focus() : ulElement.firstElementChild.querySelector(".btn-sidebar")?.focus();
-    } else if (currentButton && currentButton.closest(".search-container")) {
-        const gridContainer = currentButton.closest(".search-container");
-        const elements = Array.from(gridContainer.querySelectorAll("input"));
-        const currentIndex = elements.indexOf(currentButton);
-        const nextIndex = currentIndex + 1;
-        elements[nextIndex] ? elements[nextIndex]?.focus() : querySelectorVisible(document.querySelector(".grid"))?.focus();
-    }
-    PlaySoundFrontend("NAV_UP_DOWN");
+function getGridColumns(element) {
+    let retval = 1;
+    if (element?.classList.contains("menu")) retval = window.getComputedStyle(element).getPropertyValue("grid-template-columns").split(" ").length;
+    return retval;
 }
 
-function focusOnPreviousButton(currentButton, jumpAhead = false, jumps = 1) {
-    if (currentButton && currentButton.closest(".grid")) {
-        const gridContainer = currentButton.closest(".grid");
-        const buttons = Array.from(gridContainer.querySelectorAll(".btn-emote") || gridContainer.querySelectorAll(".btn-emoji"));
-        const currentIndex = buttons.indexOf(currentButton);
-        if (currentIndex === 0) return SEARCH_BAR.focus();
-        const step = jumpAhead ? 10 : jumps;
-        let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
-        let attempts = 0;
+function navigateUp(currentButton, jumpAhead = false, jumps = 1, checkColumns = false) {
+    if (!currentButton) return;
+    const container = currentButton.closest(".btn-list");
+    if (!container) return;
+    const buttons = Array.from(container.querySelectorAll("button:not(.hidden), input:not(.hidden)")); // CSS is Turing-Complete
+    const currentIndex = buttons.indexOf(currentButton);
+    const step = 1 * (checkColumns ? getGridColumns(container) : 1) * (jumpAhead ? 5 : jumps);
+    let nextIndex = (currentIndex - step) % buttons.length;
+    let attempts = 0;
+    if (nextIndex < 0) { 
+        if (!jumpAhead && checkColumns) {
+            if (container.classList.contains("menu") && isElementVisible(SEARCH_BAR)) return SEARCH_BAR.focus();
+            if (currentButton.classList.contains("search-input")) return document.querySelector(".sidebar-button-active")?.querySelector("button").focus();
+        }
+        nextIndex = buttons.length-1;
         
-        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
-            nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
-            attempts++;
-        }
-        
-        if (attempts < buttons.length) {
-            buttons[nextIndex]?.focus();
-            buttons[nextIndex]?.scrollIntoView({block: "center"})
-        }
-    } else if (currentButton && currentButton.closest(".popover")) {
-        const gridContainer = currentButton.closest(".popover");
-        const buttons = Array.from(gridContainer.querySelectorAll(".popover-menu-item"));
-        const currentIndex = buttons.indexOf(currentButton);
-        const step = jumps;
-        let nextIndex = ((currentIndex - step) % buttons.length + buttons.length) % buttons.length;
-        let attempts = 0;
-        
-        while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
-            nextIndex = ((nextIndex - 1) % buttons.length + buttons.length) % buttons.length;
-            attempts++;
-        }
-        
-        if (attempts < buttons.length) {
-            buttons[nextIndex]?.focus();
-        }
-    } else if (currentButton && currentButton.closest(".side-navigation")) {
-        const li = currentButton.closest("li");
-        const ulElement = li.parentElement;
-        const liElements = Array.from(ulElement.querySelectorAll("li"));
-        const currentIndex = liElements.indexOf(li);
-        let nextIndex = (currentIndex - (jumpAhead ? 2 : 1)) % liElements.length;
-        let attempts = 0;
-
-        while (!isElementVisible(liElements[nextIndex]) && attempts < liElements.length) {
-            nextIndex = (nextIndex - 1) % liElements.length;
-            attempts++;
-        }
-        const button = liElements[nextIndex]?.querySelector(".btn");
-        button ? button?.focus() : ulElement.lastElementChild.querySelector(".btn-sidebar")?.focus();
-    } else if (currentButton && currentButton.closest(".search-container")) {
-        const gridContainer = currentButton.closest(".search-container");
-        const elements = Array.from(gridContainer.querySelectorAll("input"));
-        const currentIndex = elements.indexOf(currentButton);
-        const nextIndex = currentIndex - 1;
-        elements[nextIndex] ? elements[nextIndex]?.focus() : document.querySelector(".sidebar-button-active")?.querySelector(".btn-sidebar")?.focus();
     }
-    PlaySoundFrontend("NAV_UP_DOWN");
+    while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+        if (nextIndex < 0) nextIndex = buttons.length-1;
+        nextIndex = (nextIndex - 1) % buttons.length;
+        attempts++;
+    }
+    if (attempts < buttons.length) {
+        buttons[nextIndex]?.focus();
+        buttons[nextIndex]?.scrollIntoView({block: "center"})
+        PlaySoundFrontend("NAV_UP_DOWN");
+    }
+}
+
+function navigateDown(currentButton, jumpAhead = false, jumps = 1, checkColumns = false) {
+    if (!currentButton) return;
+    const container = currentButton.closest(".btn-list");
+    if (!container) return;
+    const buttons = Array.from(container.querySelectorAll("button:not(.hidden), input:not(.hidden)"));
+    const currentIndex = buttons.indexOf(currentButton);
+    const step = 1 * (checkColumns ? getGridColumns(container) : 1) * (jumpAhead ? 5 : jumps);
+    let nextIndex = (currentIndex + step) % buttons.length;
+    let attempts = 0;
+
+    if (currentButton.classList.contains("btn-clear-search") && checkColumns) return querySelectorVisible(document.querySelector(".grid"))?.focus();
+    
+    while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+        nextIndex = (nextIndex + 1) % buttons.length;
+        attempts++;
+    }
+    
+    if (attempts < buttons.length) {
+        buttons[nextIndex]?.focus();
+        buttons[nextIndex]?.scrollIntoView({block: "center"})
+        PlaySoundFrontend("NAV_UP_DOWN");
+    }
 }

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -7,11 +7,27 @@ import { UsingMouse } from "./main.js";
 const SEARCH_BAR = document.querySelector(".search-input");
 
 document.addEventListener("keydown", (e) => {
+    const FOCUS_ELEMENT = document.activeElement;
     switch (e.key) {
-        case "ArrowUp":
+        case "PageDown":
         case "ArrowDown":
+            e.preventDefault();
+            navigateDown(FOCUS_ELEMENT, e.shiftKey, 1, true);
+            break;
+        case "PageUp":
+        case "ArrowUp":
+            e.preventDefault();
+            navigateUp(FOCUS_ELEMENT, e.shiftKey, 1, true);
+            break;
+        
         case "ArrowLeft":
+            e.preventDefault();
+            navigateUp(FOCUS_ELEMENT, e.shiftKey);
+            break;
         case "ArrowRight":
+            e.preventDefault();
+            navigateDown(FOCUS_ELEMENT, e.shiftKey);
+            break;
         case " ":
             if (document.activeElement !== SEARCH_BAR) e.preventDefault();
             break;
@@ -33,21 +49,6 @@ document.addEventListener("keyup", (e) => {
             if (FOCUS_ELEMENT.closest(".grid") && SEARCH_BAR.value !== "") return document.querySelector(".btn-clear-search").focus();
             if (FOCUS_ELEMENT.closest(".content-container")) return document.querySelector(".sidebar-button-active").querySelector(".btn")?.focus();
             return ExecuteNUICallback("CLOSE_MENU", {});
-            break;
-        case "PageDown":
-        case "ArrowDown":
-            navigateDown(FOCUS_ELEMENT, e.shiftKey, 1, true);
-            break;
-        case "PageUp":
-        case "ArrowUp":
-            navigateUp(FOCUS_ELEMENT, e.shiftKey, 1, true);
-            break;
-        
-        case "ArrowLeft":
-            navigateUp(FOCUS_ELEMENT, e.shiftKey);
-            break;
-        case "ArrowRight":
-            navigateDown(FOCUS_ELEMENT, e.shiftKey);
             break;
     }
 })

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -91,6 +91,7 @@ export async function HandleLocales() {
     if (!LOCALES || !LOCALES.data) return {};
     document.querySelectorAll("[data-locale]").forEach((el) => {
         if (LOCALES.data[el.dataset.locale]) {
+            LOCALES.data[el.dataset.locale] = LOCALES.data[el.dataset.locale].replace(/~.*?~/g, "").trim();
             if (el.hasAttribute("placeholder")) {
                 el.setAttribute("placeholder", LOCALES.data[el.dataset.locale])
             } else {

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -64,7 +64,7 @@ export function HandleEmoteSearch(search, menu = ".grid") {
         const buttons = grid.querySelectorAll("[data-emoteid]");
         buttons.forEach((button) => {
             const emoteId = button.dataset.emoteid.toLowerCase()+button.textContent.toLowerCase();
-            button.style.display = emoteId.includes(searchValue) ? "" : "none";
+            emoteId.includes(searchValue) ? button.classList.remove("hidden") : button.classList.add("hidden");
         })
     })
 }
@@ -73,7 +73,7 @@ export function querySelectorVisible(parent, query = ".btn") {
     const elements = parent?.querySelectorAll(query);
     let retval;
     for (const el of elements) {
-        if (el?.style?.display !== "none") {
+        if (!el.classList.contains("hidden")) {
             retval = el;
             break;
         }

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -35,8 +35,10 @@ export function HandleSidebarButtonPress(el) {
 
             if (CONFIG.Search) {
                 SEARCH_CONTAINER.classList.remove("hidden");
-                SEARCH_CONTAINER.querySelector(".search-input").value = "";
-                HandleEmoteSearch(""); // Bodge to clear search. Sorry.
+                if (BUTTON_CONTAINER !== PREVIOUS_ACTIVE_BUTTON_CONTAINER) {
+                    SEARCH_CONTAINER.querySelector(".search-input").value = "";
+                    HandleEmoteSearch(""); // Bodge to clear search. Sorry.
+                }
                 if (OPENED_MENU?.classList.contains("keybinds-menu")) {
                     SEARCH_CONTAINER.classList.add("hidden");
                 }
@@ -61,7 +63,7 @@ export function HandleEmoteSearch(search, menu = ".grid") {
     gridElements.forEach((grid) => {
         const buttons = grid.querySelectorAll("[data-emoteid]");
         buttons.forEach((button) => {
-            const emoteId = button.dataset.emoteid.toLowerCase();
+            const emoteId = button.dataset.emoteid.toLowerCase()+button.textContent.toLowerCase();
             button.style.display = emoteId.includes(searchValue) ? "" : "none";
         })
     })

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -89,15 +89,10 @@ export async function HandleLocales() {
     };
     const LOCALES = await req.json()
     if (!LOCALES || !LOCALES.data) return {};
+    
     document.querySelectorAll("[data-locale]").forEach((el) => {
         if (LOCALES.data[el.dataset.locale]) {
             LOCALES.data[el.dataset.locale] = LOCALES.data[el.dataset.locale].replace(/~.*?~/g, "").trim();
-            if (el.hasAttribute("placeholder")) {
-                el.setAttribute("placeholder", LOCALES.data[el.dataset.locale])
-            } else {
-                el.innerHTML = LOCALES.data[el.dataset.locale]
-                //innerHTML for the sole purpose of allowing locales to contain html (like <br>). Pretty much only for the `keybinds_description` locale.
-            }
         }
     })
     return LOCALES.data;

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -1,5 +1,5 @@
 "use strict";
-import { CONFIG } from "./main.js";
+import { CONFIG, EMOTE_TYPE_ICONS } from "./main.js";
 
 export function ClearHTMLContainer(elementClass) {
     const ELEMENT = document.querySelector(elementClass);
@@ -37,13 +37,13 @@ export function HandleSidebarButtonPress(el) {
                 SEARCH_CONTAINER.classList.remove("hidden");
                 if (BUTTON_CONTAINER !== PREVIOUS_ACTIVE_BUTTON_CONTAINER) {
                     SEARCH_CONTAINER.querySelector(".search-input").value = "";
-                    HandleEmoteSearch(""); // Bodge to clear search. Sorry.
+                    HandleEmoteFilter(""); // Bodge to clear search. Sorry.
                 }
                 if (OPENED_MENU?.classList.contains("keybinds-menu")) {
                     SEARCH_CONTAINER.classList.add("hidden");
                 }
             }
-
+            if (el.dataset.menu === "search-menu") return SEARCH_CONTAINER.querySelector(".search-input").focus();
             querySelectorVisible(OPENED_MENU)?.focus();
             break;
         case "cancelEmote":
@@ -55,9 +55,9 @@ export function HandleSidebarButtonPress(el) {
     }
 }
 
-export function HandleEmoteSearch(search, menu = ".grid") {
+export function HandleEmoteFilter(_search, menu = ".grid") {
     const CONTENT_CONTAINER = document.querySelector(".content-container");
-    const searchValue = typeof search !== "undefined" ? search?.toLowerCase() : document.querySelector(".search-input").value.toLowerCase();
+    const searchValue = typeof _search !== "undefined" ? _search?.toLowerCase() : document.querySelector(".search-input").value.toLowerCase();
     const gridElements = CONTENT_CONTAINER.querySelectorAll(menu);
     
     gridElements.forEach((grid) => {
@@ -67,6 +67,24 @@ export function HandleEmoteSearch(search, menu = ".grid") {
             emoteId.includes(searchValue) ? button.classList.remove("hidden") : button.classList.add("hidden");
         })
     })
+}
+
+export async function HandleEmoteSearch(_search) {
+    const container = document.querySelector(".search-menu");
+    const searchValue = typeof _search !== "undefined" ? _search?.toLowerCase() : document.querySelector(".search-input").value.toLowerCase();
+
+    const req = await ExecuteNUICallback("SEARCH_EMOTES", {searchTerm: searchValue});
+    let res = []
+    if (req) res = await req.json();
+    let emotes = JSON.parse(res.emotes);
+    
+    ClearHTMLContainer(".search-menu");
+    emotes.forEach((emote) => {
+        container.insertAdjacentHTML("beforeend", `
+            <button class="btn btn-emote" data-emoteid="${emote.name}" data-emotetype="${emote.data.emoteType}" data-label="${emote.data.label}">${emote.data.emoteType !== 'Emojis' ? EMOTE_TYPE_ICONS[emote.data.emoteType]+" " : ""}${emote.data.label}</button>
+            `)
+    })
+
 }
 
 export function querySelectorVisible(parent, query = ".btn") {

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -88,7 +88,7 @@ return {
     ['registered_keybind'] = "Emote (~g~%s~s~) added to keybind ~b~%s~s~",
     ['cleared_keybind'] = "Emote Slot %i has been cleared!",
     ['empty_slot'] = "Empty Slot",
-    ['keybind_description'] = "This menu is to help you visualize the emotes that you have connected to a keybind, and the control that is used. <br><br>You can modify the key bindings in the GTA settings.",
+    ['keybind_description'] = "This menu is to help you visualize the emotes that you have connected to a keybind, and the control that is used. \n\nYou can modify the key bindings in the GTA settings.",
     -- Commands descriptions
     ['cancel_emote'] = "Cancel current emote",
     ['crouch'] = "Crouch",


### PR DESCRIPTION
This PR aims to fix some of the pain points that the current implementation of the NUI menu has:

## Changes:
* Scroll wheel can now be used for "keyboard navigation"
* Show different instructional buttons for keyboard or mouse navigation (you shouldn't have to press `Alt+Enter` ever)
* Escape and Backspace go directly from emotes to sidebar (**only if the search bar is empty**, otherwise it goes to "Clear Search" first)
* Hopefully fixed the a race condition that made custom categories blank, and emote types show undefined
* Search bar now filters for both emoteid and emote label.
* You can now press space in the search bar (oops!)
* Pressing enter on search automatically focuses on first emote result
* Using the "clear search " X button actually clears the search
* Going from emote menu, to sidebar and back to the same emote menu no longer clears the search.
* Added reset buttons for moods and walking styles (oops!)
* Changed border radius for emote buttons to 0px, and added CSS variables for border radius for menu, sidebar buttons, search bar and emote buttons.
* Emoji tab should now only show if your player ped can actually use emojis.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fcd2e491-b3a5-4d71-8f65-1a1c3e451106" />