### PR TITLE
tweak (NUI, Locale, Bridge): Multiple fixes and tweaks to the NUI and checks

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -554,7 +554,7 @@ function EmoteCommandStart(args)
     if emote.emoteType == EmoteType.PROP_EMOTES
         and emote.AnimationOptions.PropTextureVariations
     then
-        local textureVariation = tonumber(args[2])
+        local textureVariation = tonumber(args[2]) or 1
         if emote.AnimationOptions.PropTextureVariations[textureVariation] then
             OnEmotePlay(name, textureVariation - 1)
             return

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -694,6 +694,15 @@ function OnEmotePlay(name, textureVariation, emoteType)
         return
     end
 
+    if IsPedBusy(PlayerPedId()) then
+        TriggerEvent('chat:addMessage', {
+            color = { 255, 0, 0 },
+            multiline = true,
+            args = { "RPEmotes", Translate('dead') }
+        })
+        return
+    end
+
     if not LocalPlayer.state.canEmote and GetConvar("onesync", "off") == "on" then return end
 
     if not DoesEntityExist(PlayerPedId()) then return false end

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -25,7 +25,7 @@ CurrentMenuSelection = {
 
 local function canPlayerEmote()
     local ped = PlayerPedId()
-    if IsEntityDead(ped) then
+    if IsEntityDead(ped) or not CanDoAction() then
         return false, Translate('dead')
     end
     if (IsPedSwimming(ped) or IsPedSwimmingUnderWater(ped)) and not Config.AllowInWater then

--- a/client/Expressions.lua
+++ b/client/Expressions.lua
@@ -1,6 +1,8 @@
 function SetPlayerPedExpression(expression, saveToKvp)
     local emote = ExpressionData[expression]
     if emote then
+        if IsPedBusy(PlayerPedId()) then return end
+
         SetFacialIdleAnimOverride(PlayerPedId(), emote.anim, 0)
         if Config.PersistentExpression and saveToKvp then SetResourceKvp("expression", emote.anim) end
     else

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -9,6 +9,7 @@
 :root {
     --color-bg-primary: rgba(46, 46, 46, 1);
     --color-bg-sidebar: rgba(46, 46, 46, 1);
+    --box-shadow-sidebar: 1rem 0px 3.5rem rgba(0,0,0,0.5);
 
     --color-text-primary: rgba(239, 239, 239, 1);
     --color-text-secondary: rgba(138, 138, 138, 1);
@@ -213,6 +214,7 @@ hr {
     background-color: var(--color-bg-sidebar);
     transition: all 200ms;
     flex-wrap: nowrap;
+    box-shadow: none;
 }
 
 .side-navigation::-webkit-scrollbar {
@@ -223,6 +225,7 @@ hr {
 .side-navigation:hover, .side-navigation:has(button:focus-visible) {
     max-width: 80%;
     flex-grow: 1;
+    box-shadow: var(--box-shadow-sidebar);
 }
 
 .side-navigation:hover::-webkit-scrollbar, .side-navigation:has(button:focus-visible)::-webkit-scrollbar {

--- a/client/NUI/js/utils.js
+++ b/client/NUI/js/utils.js
@@ -1,4 +1,5 @@
 "use strict";
+import { Locale } from "./classes.js";
 import { CONFIG, EMOTE_TYPE_ICONS } from "./main.js";
 
 export function ClearHTMLContainer(elementClass) {
@@ -14,7 +15,8 @@ export function ClearHTMLContainer(elementClass) {
 export function HandleSidebarButtonPress(el) {
     if (!el || !el.dataset.action) return;
     const CONTENT_CONTAINER = document.querySelector(".content-container");
-    const SEARCH_CONTAINER = document.querySelector(".search-container")
+    const SEARCH_CONTAINER = document.querySelector(".search-container");
+    const SEARCH_BAR = SEARCH_CONTAINER.querySelector(".search-input");
     switch (el.dataset.action) {
         case "openMenu":
             const PREVIOUS_ACTIVE_BUTTON_CONTAINER = document.querySelector(".sidebar-button-active");
@@ -36,12 +38,13 @@ export function HandleSidebarButtonPress(el) {
             if (CONFIG.Search) {
                 SEARCH_CONTAINER.classList.remove("hidden");
                 if (BUTTON_CONTAINER !== PREVIOUS_ACTIVE_BUTTON_CONTAINER) {
-                    SEARCH_CONTAINER.querySelector(".search-input").value = "";
+                    SEARCH_BAR.value = "";
                     HandleEmoteFilter(""); // Bodge to clear search. Sorry.
                 }
                 if (OPENED_MENU?.classList.contains("keybinds-menu")) {
                     SEARCH_CONTAINER.classList.add("hidden");
                 }
+                OPENED_MENU?.classList.contains("search-menu") ? SEARCH_BAR.placeholder = Locale.translate("searchemotes") : SEARCH_BAR.placeholder = Locale.translate("filteremotes").replace("%s", BUTTON_CONTAINER.querySelector("label").textContent);
             }
             if (el.dataset.menu === "search-menu") return SEARCH_CONTAINER.querySelector(".search-input").focus();
             querySelectorVisible(OPENED_MENU)?.focus();

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -96,7 +96,7 @@ function IsPlayerAiming(player)
 end
 
 function IsPedBusy(playerPed)
-    return IsEntityDead(playerPed) or IsPedRagdoll(playerPed) or IsPedGettingUp(playerPed) or IsPedInMeleeCombat(playerPed)
+    return not CanDoAction() or IsEntityDead(playerPed) or IsPedRagdoll(playerPed) or IsPedGettingUp(playerPed) or IsPedInMeleeCombat(playerPed)
 end
 
 function CanPlayerCrouchCrawl(ped)

--- a/client/emojis.lua
+++ b/client/emojis.lua
@@ -216,6 +216,7 @@ function ShowEmoji(emojiKey)
         SimpleNotify("Emoji not found!")
         return
     end
+    if not CanDoAction() then return end
 
     TriggerServerEvent('rpemotes:server:shareEmoji', emoji)
 end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -43,7 +43,7 @@ return {
     ['handsup'] = "Hands up",
     ['notvalidkey'] = "is not a valid key.",
     ['keybinds'] = "Keybinds 🔢",
-    ['searchemotes'] = "🔍 Search for Emotes",
+    ['searchemotes'] = "🔍 Search All Emotes",
     ['searchinputtitle'] = "Search:",
     ['searchmenudesc'] = "result(s) for",
     ['searchnoresult'] = "No results for search",
@@ -117,4 +117,5 @@ return {
     ['btn_contextmenu'] = "More options",
     ['btn_cursor'] = "(Hold) Toggle Cursor",
     ['btn_move_faster'] = "(Hold) Move Faster",
+    ['filteremotes'] = "Filter %s 🔍",
 }


### PR DESCRIPTION
This PR adds multiple small fixes and improvements to RPEmotes.

## Changes:
* Fix issues where the player could start emotes, expressions and emoji reactions while dead. Issue was that `CanDoAction()` bridge function was implemented, it was only used in `animation:*` event triggers, but never in the actual menu logic, which means players could always use emotes while RP-dead.
* Stop the player from opening the emote menu while RP-dead.
* Added box shadow to the NUI sidebar, and a CSS variable for it.
* Changed `Search for Emotes` locale to `Search All Emotes` in the full emote search menu, and added a new locale `Filter {Category Name}` for the other search bars in the NUI.
  While still not the best solution, this will make the search bar a bit less confusing.
  
<img width="445" height="671" alt="image" src="https://github.com/user-attachments/assets/de04daf4-504b-42c5-af30-f25b0df28abb" />
<img width="441" height="671" alt="image" src="https://github.com/user-attachments/assets/24f78de1-e29f-45d5-a0e5-e3dc96c5a963" />
