### PR TITLE
fix (NUI & Search): Correctly filter emotes based on player model, and update the NUI

### DIFF
--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -626,7 +626,10 @@ function SearchEmotes(input)
     if Config.SharedEmotesEnabled then
         for emoteName, emoteData in pairs(SharedEmoteData) do
             if matchesSearchTerm(emoteName, emoteData, input) then
-                results[#results + 1] = { table = EmoteType.SHARED, name = emoteName, data = emoteData }
+                -- Also check model compat here.
+                if not CachedPlayerModel or IsModelCompatible(CachedPlayerModel, emoteName) then
+                    results[#results + 1] = { table = EmoteType.SHARED, name = emoteName, data = emoteData }
+                end
             end
         end
     end

--- a/client/NUI/EmoteMenuNUI.lua
+++ b/client/NUI/EmoteMenuNUI.lua
@@ -249,15 +249,17 @@ end
 
 AddEventHandler("rpemotes:internal:sendMenuDataToNUI", function()
     while not nuiReady or not initialDataLoaded do Citizen.Wait(10) end
+    DebugPrint("[ NUI EMOTES BUILT ]")
     SendNUIMessage(dataForMenu)
     for key, val in pairs(dataForMenu) do
         dataForMenu[key] = {}
     end
+    dataForMenu.type = "BUILD_EMOTE_MENUS"
 end)
 
 AddEventHandler("rpemotes:internal:sendKeybindsDataToNUI", function(binds)
     while not nuiReady or not initialDataLoaded do Citizen.Wait(10) end
-
+    DebugPrint("[ NUI KEYBINDS BUILT ]")
     SendNUIMessage({
         type = "BUILD_KEYBINDS_MENU",
         ["keybinds"] = binds

--- a/client/NUI/css/main.css
+++ b/client/NUI/css/main.css
@@ -10,6 +10,7 @@
     --color-bg-primary: rgba(46, 46, 46, 1);
     --color-bg-sidebar: rgba(46, 46, 46, 1);
     --box-shadow-sidebar: 1rem 0px 3.5rem rgba(0,0,0,0.5);
+    --box-shadow-menu: 0px 0px 2rem rgba(0,0,0,0.4);
 
     --color-text-primary: rgba(239, 239, 239, 1);
     --color-text-secondary: rgba(138, 138, 138, 1);
@@ -147,6 +148,7 @@ hr {
     height: 60vh;
     overflow: auto;
     border-radius: var(--border-radius-menu);
+    box-shadow: var(--box-shadow-menu);
 }
 
 .header-container {


### PR DESCRIPTION
Another round of fixes for the NUI (and Search).

## Changes:
* Added drop shadow to the main menu & CSS variable for it, for easy change.
* Fixed the NUI not updating when changing peds (this would cause us to only see Human emotes, not other ones).
* Fixed Full Emote Search not filtering shared emotes based on player model.