### PR TITLE
fix (NUI, Emotes): Better way of filtering hidden buttons, and fast-exit exploit fix

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -197,7 +197,13 @@ local function exitScenario()
         or ChosenScenarioType == ScenarioType.SCENARIO)
         and IsInAnimation
     then
-        ClearPedTasksImmediately(PlayerPedId())
+        local playerPed = PlayerPedId()
+        if IsPedInAnyVehicle(playerPed) then
+            ClearPedSecondaryTask(playerPed)
+            ClearPedTasks(playerPed)
+        else
+            ClearPedTasksImmediately(playerPed)
+        end
         IsInAnimation = false
         DebugPrint("Forced scenario exit")
     end
@@ -829,7 +835,13 @@ function OnEmotePlay(name, textureVariation, emoteType)
     end
 
     if IsPedUsingAnyScenario(PlayerPedId()) or IsPedActiveInScenario(PlayerPedId()) then
-        ClearPedTasksImmediately(PlayerPedId())
+        local playerPed = PlayerPedId()
+        if IsPedInAnyVehicle(playerPed) then
+            ClearPedSecondaryTask(playerPed)
+            ClearPedTasks(playerPed)
+        else
+            ClearPedTasksImmediately(playerPed)
+        end
     end
 
     local flags = animOption?.Flag or movementType or 0

--- a/client/NUI/js/navigation.js
+++ b/client/NUI/js/navigation.js
@@ -109,6 +109,11 @@ function isElementVisible(element) {
     return !display;
 }
 
+function isElementVisibleBetter(element) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+    return element && element.offsetParent !== null;
+}
+
 function getGridColumns(element) {
     let retval = 1;
     if (element?.classList.contains("menu")) retval = window.getComputedStyle(element).getPropertyValue("grid-template-columns").split(" ").length;
@@ -132,7 +137,7 @@ function navigateUp(currentButton, jumpAhead = false, jumps = 1, checkColumns = 
         nextIndex = buttons.length-1;
         
     }
-    while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+    while (!isElementVisibleBetter(buttons[nextIndex]) && attempts < buttons.length) {
         if (nextIndex < 0) nextIndex = buttons.length-1;
         nextIndex = (nextIndex - 1) % buttons.length;
         attempts++;
@@ -156,7 +161,7 @@ function navigateDown(currentButton, jumpAhead = false, jumps = 1, checkColumns 
 
     if (currentButton.classList.contains("btn-clear-search") && checkColumns) return querySelectorVisible(document.querySelector(".grid"))?.focus();
     
-    while (!isElementVisible(buttons[nextIndex]) && attempts < buttons.length) {
+    while (!isElementVisibleBetter(buttons[nextIndex]) && attempts < buttons.length) {
         nextIndex = (nextIndex + 1) % buttons.length;
         attempts++;
     }


### PR DESCRIPTION
This PR addresses the following issues:
* NUI keyboard navigation should (hopefully!) now correctly filter out all hidden buttons. Issue was that `getComputedStyle().getPropertyValue()` JS methods did not return the correct display value that the element *inherited* (ex: display: none set by the parent). We are now using `element.offsetParent` instead.

* Fixed an exploit where a player could instantly exit the vehicle by first starting *looping* vehicle animation (/e elbow2), then a scenario (/e windowshop) and then canceling the animation. 
  Issue was that the scenario would not actually play by itself, but since the ped is already in an animation, the game thinks it does (???), triggering `IsPedUsingAnyScenario()`, and eventually running `ClearPedTasksImmediately(playerPed)`. We are now checking if the ped is in a vehicle first, and use `ClearPedTasks() & ClearPedSecondaryTask()`, to gracefully clear them while in-vehicle.