### PR TITLE
fix (Multiple Areas): Remove `lua54` fxmanifest field & various small fixes.

### DIFF
--- a/NativeUI.lua
+++ b/NativeUI.lua
@@ -2916,7 +2916,7 @@ function UIMenu:ProcessControl()
         self:Visible(true)
 
         if Config.PreviewPed then
-            ShowPedMenu(zoom)
+            ShowPedMenu(currentZoomState)
         else
             ClosePedMenu()
             ShowPed = false

--- a/client/Binoculars.lua
+++ b/client/Binoculars.lua
@@ -70,7 +70,7 @@ function UseBinocular()
         cam = CreateCam("DEFAULT_SCRIPTED_FLY_CAMERA", true)
 
         AttachCamToEntity(cam, PlayerPedId(), 0.0, 0.0, 1.2, true)
-        SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()))
+        SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()), 2)
         SetCamFov(cam, fov)
         RenderScriptCams(true, false, 0, true, false)
         PushScaleformMovieFunction(scaleform_bin, "SET_CAM_LOGO")

--- a/client/Bridge.lua
+++ b/client/Bridge.lua
@@ -74,19 +74,13 @@ end)
 if Config.Keybinding then
     RegisterNetEvent('animations:client:BindEmote', function(args)
         if CanDoAction() then
-            EmoteBindStart(nil, args)
-        end
-    end)
-
-    RegisterNetEvent('animations:client:EmoteBinds', function()
-        if CanDoAction() then
-            ListKeybinds()
+            EmoteBindStart(args)
         end
     end)
 
     RegisterNetEvent('animations:client:EmoteDelete', function(args)
         if CanDoAction() then
-            DeleteEmote(args)
+            DeleteEmoteBind(args)
         end
     end)
 end

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -153,7 +153,7 @@ local function runAnimationThread()
 
             Wait(sleep)
         end
-        CleanUpPlacement(ped)
+        CleanUpPlacement(pPed)
     end)
 end
 
@@ -198,7 +198,7 @@ local function exitScenario()
         and IsInAnimation
     then
         local playerPed = PlayerPedId()
-        if IsPedInAnyVehicle(playerPed) then
+        if IsPedInAnyVehicle(playerPed, false) then
             ClearPedSecondaryTask(playerPed)
             ClearPedTasks(playerPed)
         else
@@ -489,7 +489,7 @@ function EmoteMenuStartClone(name, emoteType)
     if emoteType == EmoteType.EXPRESSIONS then
         local emote = ExpressionData[name]
         if emote then
-            SetFacialIdleAnimOverride(ClonedPed, emote.anim, true)
+            SetFacialIdleAnimOverride(ClonedPed, emote.anim, 0)
         else
             ClearFacialIdleAnimOverride(ClonedPed)
         end
@@ -836,7 +836,7 @@ function OnEmotePlay(name, textureVariation, emoteType)
 
     if IsPedUsingAnyScenario(PlayerPedId()) or IsPedActiveInScenario(PlayerPedId()) then
         local playerPed = PlayerPedId()
-        if IsPedInAnyVehicle(playerPed) then
+        if IsPedInAnyVehicle(playerPed, false) then
             ClearPedSecondaryTask(playerPed)
             ClearPedTasks(playerPed)
         else

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -14,7 +14,7 @@ local isMenuProcessing = false
 local isWaitingForPed = false
 keybindMenu = nil -- Global variable. Scary!
 favoriteMenu = nil -- Global variable. Scary!
-local currentZoomState = false
+currentZoomState = false -- Global variable needed, so it can be used by `ShowPedMenu()` in NativeUI.
 local dataForKeybind = {}
 
 -- Tracks currently selected menu item for instruction button visibility

--- a/client/NewsCam.lua
+++ b/client/NewsCam.lua
@@ -94,7 +94,7 @@ function UseNewscam()
         cam = CreateCam("DEFAULT_SCRIPTED_FLY_CAMERA", true)
 
         AttachCamToEntity(cam, PlayerPedId(), 0.0, 0.0, 1.2, true)
-        SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()))
+        SetCamRot(cam, 0.0, 0.0, GetEntityHeading(PlayerPedId()), 2)
         SetCamFov(cam, fov)
         RenderScriptCams(true, false, 0, true, false)
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,6 @@ game 'gta5'
 description 'rpemotes-reborn'
 version '2.1.0'
 
-lua54 'yes'
 use_experimental_fxv2_oal 'yes'
 
 provide "rpemotes"
@@ -13,7 +12,7 @@ dependencies {
     '/onesync'
 }
 
-ui_page('client/NUI/index.html')
+ui_page 'client/NUI/index.html'
 
 files {
     'conditionalanims.meta',


### PR DESCRIPTION
This PR aims to fix some native usage inconsistencies introduced in the latest releases. While most of the changes won't impact the resource's usage, it's good to have some code cleanup from time to time. All changes related to GTA natives are purely cosmetic, but at least LLMs won't complain anymore.

## Changes:

* Remove now-redundant `lua54` field in fxmanifest. Lua 5.4 is now the only Lua runtime in FiveM. https://forum.cfx.re/t/removal-of-lua-5-3-support/5335232
* Fixed various instances where GTA natives would have missing or inconsistent arguments. This is due to either bad documentation when they were initially written, or me forgetting to check the docs when writing code. No bugs were fixed here, since sometimes native do have default values for args.
* Fixed Keybinding-related event handlers in `Bridge.lua`, to now use the refactored keybinding functions. (Keybinding refactor was introduced in Nov 2025, and this area was missed).
* Fixed an issue with `ShowPedMenu()` in NativeUI, which used an non-existent variable to set the ped's zoom level, when toggling the ped preview in menu. This caused the ped to always be zoomed out when toggling the preview on, even when previewing Mood emotions. Fixed it by making `currentZoomState` variable global in `EmoteMenu.lua`, and using that in NativeUI.