### PR TITLE
fix (Binoculars & Newscam): Use correct function for binos and newscam emotes & turn player ped with the camera

### DIFF
--- a/client/Binoculars.lua
+++ b/client/Binoculars.lua
@@ -35,7 +35,7 @@ function UseBinocular()
 
     if not IsUsingBinoculars then
         EmoteCommandStart({ "binoculars", 1 })
-        PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
+        PlayPedAmbientSpeechNative(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
         SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
     end
 

--- a/client/Binoculars.lua
+++ b/client/Binoculars.lua
@@ -32,32 +32,16 @@ function UseBinocular()
     if IsPedSittingInAnyVehicle(PlayerPedId()) then return end
     if IsInActionWithErrorMessage({ IsUsingBinoculars = true }) then return end
     if not CanDoAction() then return end
+
+    if not IsUsingBinoculars then
+        EmoteCommandStart({ "binoculars", 1 })
+        PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
+        SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
+    end
+
     IsUsingBinoculars = not IsUsingBinoculars
 
     if IsUsingBinoculars then
-        CreateThread(function()
-            DestroyAllProps()
-            ClearPedTasks(PlayerPedId())
-            LoadAnim("amb@world_human_binoculars@male@idle_a")
-
-            -- attach the prop to the player
-            local boneIndex = GetPedBoneIndex(PlayerPedId(), 28422)
-            local x, y, z = table.unpack(GetEntityCoords(PlayerPedId(), true))
-            LoadPropDict("prop_binoc_01")
-            -- prop_binoc = CreateObject(`prop_binoc_01`, x, y, z + 0.2, true, true, true)
-            -- AttachEntityToEntity(prop_binoc, PlayerPedId(), boneIndex, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, true, true,
-            --     false, true, 1, true)
-            OnEmotePlay("binoculars")
-
-            TaskPlayAnim(PlayerPedId(), "amb@world_human_binoculars@male@idle_a", "idle_c", 5.0, 5.0, -1, 51, 0,
-                false, false, false)
-            PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
-            SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
-
-            RemoveAnimDict("amb@world_human_binoculars@male@idle_a")
-            SetModelAsNoLongerNeeded("prop_binoc_01")
-        end)
-
         Wait(200)
 
         SetTimecycleModifier("default")

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -223,6 +223,9 @@ function EmoteCancel(force)
     PtfxPrompt = false
     Pointing = false
 
+    if IsUsingNewscam then IsUsingNewscam = false end
+    if IsUsingBinoculars then IsUsingBinoculars = false end
+
     if IsInAnimation then
         local ped = PlayerPedId()
         if LocalPlayer.state.ptfx then

--- a/client/NewsCam.lua
+++ b/client/NewsCam.lua
@@ -37,6 +37,8 @@ function UseNewscam()
 
     if not IsUsingNewscam then
         EmoteCommandStart({ "newscam", 1 })
+        PlayPedAmbientSpeechNative(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
+        SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
     end
 
     IsUsingNewscam = not IsUsingNewscam

--- a/client/NewsCam.lua
+++ b/client/NewsCam.lua
@@ -34,31 +34,14 @@ function UseNewscam()
     if IsPedSittingInAnyVehicle(PlayerPedId()) then return end
     if IsInActionWithErrorMessage({IsUsingNewscam = true }) then return end
     if not CanDoAction() then return end
+
+    if not IsUsingNewscam then
+        EmoteCommandStart({ "newscam", 1 })
+    end
+
     IsUsingNewscam = not IsUsingNewscam
 
     if IsUsingNewscam then
-        CreateThread(function()
-            DestroyAllProps()
-            ClearPedTasks(PlayerPedId())
-            LoadAnim("missfinale_c2mcs_1")
-
-            -- attach the prop to the player
-            local boneIndex = GetPedBoneIndex(PlayerPedId(), 28422)
-            local x, y, z = table.unpack(GetEntityCoords(PlayerPedId(), true))
-            LoadPropDict("prop_v_cam_01")
-
-            -- prop_newscam = CreateObject(`prop_v_cam_01`, x, y, z + 0.2, true, true, true)
-            -- AttachEntityToEntity(prop_newscam, PlayerPedId(), boneIndex, 0.0, 0.03, 0.01, 0.0, 0.0, 0.0, true, true, false, true, 1, true)
-            OnEmotePlay("newscam")
-
-            TaskPlayAnim(PlayerPedId(), "missfinale_c2mcs_1", "fin_c2_mcs_1_camman", 5.0, 5.0, -1, 51, 0, false, false, false)
-            PlayAmbientSpeech1(PlayerPedId(), "GENERIC_CURSE_MED", "SPEECH_PARAMS_FORCE")
-            SetCurrentPedWeapon(PlayerPedId(), `WEAPON_UNARMED`, true)
-
-            RemoveAnimDict("missfinale_c2mcs_1")
-            SetModelAsNoLongerNeeded("prop_v_cam_01")
-        end)
-
         Wait(200)
         SetTimecycleModifier("default")
         SetTimecycleModifierStrength(0.3)

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -358,6 +358,7 @@ function HandleZoomAndCheckRotation(cam, fov)
             fov = current_fov
         end
         SetCamFov(cam, current_fov + (fov - current_fov) * 0.05)
+        SetEntityHeading(lPed, rotation.z) -- Otherwise, the player would be able to look behind them without their ped turning.
     else
         if IsControlJustPressed(0, 17) then -- Scrollup
             fov = math.max(fov - zoomspeed, fov_min)


### PR DESCRIPTION
This PR aims to address 2 main defects with the current implementation of `/binoculars` and `/newscam`: the missing props, and player peds not turning.

## RCA:
When modifying the binos and newscam scripts to use the same emote functions as the menu, a regression was introduced, we did not take into account that, since we already start the binos / news script, the animation would not be able to play (like you cannot play any other animation from the menu). 

This caused the emote to quietly fail, while still playing *a animation*, due to old code being left out in the script, thus no prop, but the animation playing.

## Fix:
* Use the correct emote function to start `/binoculars` and `/newscam`.
* Cleanup binos and newscam scripts, to not contain old animation code.
* Stop binos and newscam scripts (if active), if the player hits the `Emote cancel` button, command, or function.
* Fix an older bug, where the player ped would not turn around with the binos / news camera, allowing players to look behind them without other players knowing.
